### PR TITLE
Add a page for each organizations

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -18,13 +18,30 @@ exports.createPages = async ({ graphql, actions }) => {
           }
         }
       }
+      organizations: allAirtable(filter: {table: {eq: "Organizations"}}) {
+        nodes {
+          data {
+            Slug
+          }
+        }
+      }
     }
   `)
 
+  // Create the sectors pages
   data.sectors.nodes.forEach(({ data }) => {
     createPage({
       path: `/sectors/${data.Slug}`,
       component: path.resolve(`./src/templates/sector.js`),
+      context: { slug: data.Slug },
+    })
+  })
+
+  // Create the organizations pages
+  data.organizations.nodes.forEach(({ data }) => {
+    createPage({
+      path: `/organizations/${data.Slug}`,
+      component: path.resolve(`./src/templates/organization.js`),
       context: { slug: data.Slug },
     })
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -926,6 +926,14 @@
         "@fortawesome/fontawesome-common-types": "^0.2.26"
       }
     },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.12.0.tgz",
+      "integrity": "sha512-50uCFzVUki3wfmFmrMNLFhOt8dP6YZ53zwR4dK9FR7Lwq1IVHXnSBb8MtGLe3urLJ2sA+CSu7Pc7s3i6/zLxmA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.26"
+      }
+    },
     "@fortawesome/free-regular-svg-icons": {
       "version": "5.12.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
+    "@fortawesome/free-brands-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
     "gatsby": "^2.18.12",
     "gatsby-image": "^2.2.34",

--- a/src/components/OrganizationCard.js
+++ b/src/components/OrganizationCard.js
@@ -1,8 +1,11 @@
 import React from "react"
+import { Link } from "gatsby"
 import Img from "gatsby-image"
+import PropTypes from "prop-types"
+
 import { OrganizationTag, OrganizationLocation, OrganizationHeadcount, OrganizationOrgType } from "../components/OrganizationAttributes"
 
-const OrganizationCard = ({ title, description, tags, homepage, location, logo, headcount, orgType, currentFilter, onApplyFilter }) => (
+const OrganizationCard = ({ title, description, tags, slug, homepage, location, logo, headcount, orgType, currentFilter, onApplyFilter }) => (
   <div className="flex items-center border-b border-gray-400 p-3 text-gray-900">
     <div className="mr-5 w-16 flex-shrink-0 hidden sm:block">
     {logo &&
@@ -11,9 +14,12 @@ const OrganizationCard = ({ title, description, tags, homepage, location, logo, 
     </div>
     <div>
       <p>
-        <a className="font-bold hover:text-teal-500 mr-2" href={homepage} target="_blank" rel="noopener noreferrer">
-          {title}
-        </a>
+        { slug
+          ? <Link to={`/organizations/${slug}`} className="font-bold hover:text-teal-500 mr-2">{title}</Link>
+          : <a className="font-bold hover:text-teal-500 mr-2" href={homepage} target="_blank" rel="noopener noreferrer">
+              {title}
+            </a>
+        }
 
         {description}
       </p>
@@ -21,7 +27,7 @@ const OrganizationCard = ({ title, description, tags, homepage, location, logo, 
         {
           tags && tags.map((tag, i) =>
             <OrganizationTag
-              onClick={e => onApplyFilter.byTag(tag)}
+              onClick={e => onApplyFilter.byTag && onApplyFilter.byTag(tag)}
               key={i}
               active={tag === currentFilter.byTag}
               text={tag} />
@@ -29,13 +35,13 @@ const OrganizationCard = ({ title, description, tags, homepage, location, logo, 
         }
         {location &&
           <OrganizationLocation
-            onClick={e => onApplyFilter.byLocation(location)}
+            onClick={e => onApplyFilter.byLocation && onApplyFilter.byLocation(location)}
             key='location'
             active={location === currentFilter.byLocation}
             text={location} />}
         {headcount &&
           <OrganizationHeadcount
-            onClick={e => onApplyFilter.byHeadcount(headcount)}
+            onClick={e => onApplyFilter.byHeadcount && onApplyFilter.byHeadcount(headcount)}
             key='headcount'
             active={headcount === currentFilter.byHeadcount}
             text={headcount}
@@ -43,7 +49,7 @@ const OrganizationCard = ({ title, description, tags, homepage, location, logo, 
         }
         {orgType &&
           <OrganizationOrgType
-            onClick={e => onApplyFilter.byOrgType(orgType)}
+            onClick={e => onApplyFilter.byOrgType && onApplyFilter.byOrgType(orgType)}
             key='orgtype'
             active={orgType === currentFilter.byOrgType}
             text={orgType}
@@ -53,4 +59,24 @@ const OrganizationCard = ({ title, description, tags, homepage, location, logo, 
     </div>
   </div>
 )
+
+OrganizationCard.defaultProps = {
+  currentFilter: {},
+  onApplyFilter: {},
+}
+
+OrganizationCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  tags: PropTypes.arrayOf(PropTypes.string),
+  slug: PropTypes.string,
+  homepage: PropTypes.string,
+  location: PropTypes.string,
+  logo: PropTypes.object,
+  headcount: PropTypes.string,
+  orgType: PropTypes.string,
+  currentFilter: PropTypes.object,
+  onApplyFilter: PropTypes.object,
+}
+
 export default OrganizationCard

--- a/src/components/OrganizationSocial.js
+++ b/src/components/OrganizationSocial.js
@@ -1,0 +1,39 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faLink } from '@fortawesome/free-solid-svg-icons'
+import { faLinkedin, faTwitter } from '@fortawesome/free-brands-svg-icons'
+
+const OrganizationSocial = ({ homepage, linkedIn, twitter }) => (
+  <div className="flex">
+    {homepage &&
+      <div className={`flex-1 text-center px-4 py-2 m-2 ${(linkedIn || twitter) && "border-r-4"}`}>
+        <a className="hover:text-teal-500 text-gray-700" href={homepage} target="_blank" rel="noopener noreferrer">
+          <FontAwesomeIcon icon={faLink} className="mr-2" />Homepage
+        </a>
+      </div>
+    }
+    {linkedIn &&
+      <div className={`flex-1 text-center px-4 py-2 m-2 ${(twitter) ? "border-r-4" : ""}`}>
+        <a className="hover:text-teal-500 mr-2 text-gray-700" href={linkedIn} target="_blank" rel="noopener noreferrer">
+          <FontAwesomeIcon icon={faLinkedin} className="mr-2" />LinkedIn
+        </a>
+      </div>
+    }
+    {twitter &&
+      <div className="flex-1 text-center px-4 py-2 m-2">
+        <a className="hover:text-teal-500 mr-2" href={twitter} target="_blank" rel="noopener noreferrer">
+          <FontAwesomeIcon icon={faTwitter} className="mr-2" />Twitter
+        </a>
+      </div>
+    }
+  </div>
+)
+
+OrganizationSocial.propTypes = {
+  homepage: PropTypes.string,
+  linkedIn: PropTypes.string,
+  twitter: PropTypes.string,
+}
+
+export default OrganizationSocial

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -1,0 +1,16 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+const Section = ({ title, children }) => (
+  <div className="bg-white mt-3 p-3 border-b border-gray-400">
+    {title && <h4 className="text-lg">{title}</h4>}
+    {children}
+  </div>
+)
+
+Section.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.node,
+}
+
+export default Section

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -1,0 +1,85 @@
+import React from "react"
+import { graphql } from 'gatsby'
+
+import OrganizationCard from "../components/OrganizationCard"
+import { filterDuplicateAndEmptyItems } from "../utils/array"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+const OrganizationTemplate = ({ data }) => {
+
+  const siteTitle = data.site.siteMetadata.title
+  const organizationData = data.airtable.data
+
+  const org = {
+    title: organizationData.Name,
+    description: organizationData.Tagline || organizationData.About,
+    tags: organizationData.Tags,
+    location: filterDuplicateAndEmptyItems(organizationData.City, organizationData.State_Province, organizationData.Country).join(', '),
+    headcount: organizationData.Headcount,
+    orgType: organizationData.Organization_Type,
+    homepage: organizationData.Homepage,
+    logo: organizationData.Logo && organizationData.Logo.localFiles[0] && organizationData.Logo.localFiles[0].childImageSharp
+      && organizationData.Logo.localFiles[0].childImageSharp.fixed,
+  }
+
+  return <Layout contentClassName="bg-gray-200">
+    <SEO title={`${org.title} is solving climate change - ${siteTitle}`} />
+
+    <div className="max-w-4xl mx-auto pb-4">
+      <h2 className="text-3xl tracking-wide font-light p-3 md:mt-4">
+        {org.title}
+      </h2>
+      {/*WIP: we need to create a proper organization UI page */}
+      <div className="bg-white">
+        <OrganizationCard
+          title={org.title}
+          description={org.description}
+          tags={org.tags}
+          location={org.location}
+          headcount={org.headcount}
+          orgType={org.orgType}
+          homepage={org.homepage}
+          logo={org.logo}
+        />
+      </div>
+    </div>
+  </Layout>
+}
+
+export const query = graphql`
+  query OrganizationPageQuery($slug: String) {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+
+    airtable(table: { eq: "Organizations" }, data: { Slug: { eq: $slug } }) {
+      data {
+        Name
+        Homepage
+        About
+        Tags
+        Tagline
+        City
+        State_Province
+        Country
+        Organization_Type
+        Headcount
+        Logo {
+          localFiles {
+            childImageSharp {
+              fixed(width: 64, height: 64, fit: CONTAIN, background: "white") {
+                ...GatsbyImageSharpFixed
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+export default OrganizationTemplate

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -1,49 +1,69 @@
 import React from "react"
-import { graphql } from 'gatsby'
+import { graphql, Link } from "gatsby"
+import Img from "gatsby-image"
 
-import OrganizationCard from "../components/OrganizationCard"
-import { filterDuplicateAndEmptyItems } from "../utils/array"
-
+import { OrganizationTag, OrganizationLocation, OrganizationHeadcount, OrganizationOrgType } from "../components/OrganizationAttributes"
+import OrganizationSocial from "../components/OrganizationSocial"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
+import Section from "../components/Section"
+
+import { filterDuplicateAndEmptyItems } from "../utils/array"
 
 const OrganizationTemplate = ({ data }) => {
-
   const siteTitle = data.site.siteMetadata.title
-  const organizationData = data.airtable.data
+  const orgData = data.airtable.data
 
+  const sector = orgData.Sector[0]?.data || {}
   const org = {
-    title: organizationData.Name,
-    description: organizationData.Tagline || organizationData.About,
-    tags: organizationData.Tags,
-    location: filterDuplicateAndEmptyItems(organizationData.City, organizationData.State_Province, organizationData.Country).join(', '),
-    headcount: organizationData.Headcount,
-    orgType: organizationData.Organization_Type,
-    homepage: organizationData.Homepage,
-    logo: organizationData.Logo && organizationData.Logo.localFiles[0] && organizationData.Logo.localFiles[0].childImageSharp
-      && organizationData.Logo.localFiles[0].childImageSharp.fixed,
+    logo: orgData.Logo?.localFiles?.[0]?.childImageSharp?.fixed,
+    title: orgData.Name,
+    sector: {
+      name: sector.Name,
+      slug: sector.Slug,
+    },
+    tagline: orgData.Tagline,
+    about: orgData.About && orgData.About.replace(orgData.Tagline, ""),
+    location: filterDuplicateAndEmptyItems(orgData.City, orgData.State_Province, orgData.Country).join(", "),
+    headcount: orgData.Headcount,
+    orgType: orgData.Organization_Type,
+    homepage: orgData.Homepage,
+    linkedIn: orgData.LinkedIn,
+    twitter: orgData.Twitter,
+    tags: orgData.Tags,
   }
 
   return <Layout contentClassName="bg-gray-200">
-    <SEO title={`${org.title} is solving climate change - ${siteTitle}`} />
+    <SEO
+      title={`${org.title} is solving climate change - ${siteTitle}`}
+      description={`${org.title} is on ${siteTitle}. ${org.tagline}`}
+    />
 
     <div className="max-w-4xl mx-auto pb-4">
-      <h2 className="text-3xl tracking-wide font-light p-3 md:mt-4">
-        {org.title}
-      </h2>
-      {/*WIP: we need to create a proper organization UI page */}
-      <div className="bg-white">
-        <OrganizationCard
-          title={org.title}
-          description={org.description}
-          tags={org.tags}
-          location={org.location}
-          headcount={org.headcount}
-          orgType={org.orgType}
-          homepage={org.homepage}
-          logo={org.logo}
-        />
-      </div>
+      {org.logo &&
+        <div className="p-3 mt-3 lg:my-6 text-center">
+          <Img fixed={org.logo}/>
+        </div>
+      }
+      <Section>
+        <h2 className="text-3xl tracking-wide font-light">{org.title}</h2>
+        {org.sector && <Link to={`/sectors/${org.sector.slug}`} className="block text-teal-700 hover:text-teal-900">{org.sector.name}</Link> }
+        <h3 className="font-bold my-3 pl-3 lg:my-6 border-l-8 border-teal-500 border-solid">{org.tagline}</h3>
+        {org.about && org.about !== org.tagline && <div className="py-3">{org.about}</div>}
+        {org.location && <OrganizationLocation key="location" text={org.location}/>}
+        {org.headcount && <OrganizationHeadcount key="headcount" text={org.headcount}/>}
+        {org.orgType && <OrganizationOrgType key="orgtype" text={org.orgType}/>}
+      </Section>
+      <Section title="Social">
+        <OrganizationSocial homepage={org.homepage} linkedIn={org.linkedIn} twitter={org.twitter}/>
+      </Section>
+
+      {org.tags &&
+        <Section title="Tags">
+          {org.tags.map(tag => <OrganizationTag key={tag} text={tag} />)}
+        </Section>
+      }
+      {/*TODO: implement suggest edit button // <button>Suggest an edit</button>*/}
     </div>
   </Layout>
 }
@@ -58,25 +78,33 @@ export const query = graphql`
 
     airtable(table: { eq: "Organizations" }, data: { Slug: { eq: $slug } }) {
       data {
-        Name
-        Homepage
-        About
-        Tags
-        Tagline
-        City
-        State_Province
-        Country
-        Organization_Type
-        Headcount
         Logo {
           localFiles {
             childImageSharp {
-              fixed(width: 64, height: 64, fit: CONTAIN, background: "white") {
+              fixed(width: 200, height: 200, fit: CONTAIN, background: "transparent") {
                 ...GatsbyImageSharpFixed
               }
             }
           }
         }
+        Name
+        Sector {
+          data {
+            Name
+            Slug
+          }
+        }
+        Tagline
+        About
+        City
+        State_Province
+        Country
+        Headcount
+        Organization_Type
+        Homepage
+        LinkedIn
+        Twitter
+        Tags
       }
     }
   }

--- a/src/templates/sector.js
+++ b/src/templates/sector.js
@@ -2,6 +2,7 @@ import React from "react"
 import { graphql } from 'gatsby'
 
 import { stringCompare } from "../utils/string"
+import { filterDuplicateAndEmptyItems } from "../utils/array"
 
 import Layout from "../components/layout"
 import OrganizationCard from "../components/OrganizationCard"
@@ -13,20 +14,17 @@ const SectorTemplate = ({ data }) => {
 
   const name = data.airtable.data.Name
 
-  function filterDuplicateAndEmptyItems(...items) {
-    return [...new Set(items)].filter(m=>m);
-  }
-
   // Avoid breaking if the sector has no orgs + map out nested data object
   let organizations = (data.airtable.data.Organizations || [])
     .map(o => o.data)
-    .map(({ Name, About, Tags, Homepage, City, State_Province, Country, Tagline, Logo, Headcount, Organization_Type }) => ({
+    .map(({ Name, About, Tags, Slug, Homepage, City, State_Province, Country, Tagline, Logo, Headcount, Organization_Type }) => ({
       title: Name,
       description: Tagline || About,
       tags: Tags,
       location: filterDuplicateAndEmptyItems(City, State_Province, Country).join(', '),
       headcount: Headcount,
       orgType: Organization_Type,
+      slug: Slug,
       homepage: Homepage,
       logo: Logo && Logo.localFiles[0] && Logo.localFiles[0].childImageSharp && Logo.localFiles[0].childImageSharp.fixed,
     }));
@@ -56,6 +54,7 @@ const SectorTemplate = ({ data }) => {
               location={org.location}
               headcount={org.headcount}
               orgType={org.orgType}
+              slug={org.slug}
               homepage={org.homepage}
               logo={org.logo}
               key={index}

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -1,0 +1,3 @@
+// Filter duplicated and empty items from an array
+export const filterDuplicateAndEmptyItems = (...items) =>
+  [...new Set(items)].filter(m => m)


### PR DESCRIPTION
Related to #13

**WIP** - not production ready

Create a page for each organizations.
Each page will be available at `https://climatescape.org/organizations/:orgSlug`.

Currently, I simply re-use the `OrganizationCard` component but the idea will be to create a more specific design for this page. (that's why I flagged this one as WIP)

Currently it looks like this: 
![Screenshot from 2020-02-01 17-01-13](https://user-images.githubusercontent.com/1302282/73595058-85857580-4514-11ea-9538-a389f2690b86.png)

----

- [x] Create an organization template
- [x] Use gatsby-node to create the organizations pages
- [x] Update the link in the organizations list to point to the new organization page
- [x] Develop the organization page UI
- [x] Improve the organization page SEO tag

----

  - As I don't have the `AIRTABLE_API_KEY`, I can't build the website locally
  - First time user of Gatsby/GraphQL

I coded all this "blinded" (as I don't have the api key), so some issues may occur :see_no_evil: 
