### PR TITLE
Create a page listing all organizations

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -14,7 +14,8 @@ exports.createPages = async ({ graphql, actions }) => {
       sectors: allAirtable(filter: {table: {eq: "Sectors"}}) {
         nodes {
           data {
-            Slug
+            slug: Slug
+            name: Name
           }
         }
       }
@@ -31,9 +32,12 @@ exports.createPages = async ({ graphql, actions }) => {
   // Create the sectors pages
   data.sectors.nodes.forEach(({ data }) => {
     createPage({
-      path: `/sectors/${data.Slug}`,
-      component: path.resolve(`./src/templates/sector.js`),
-      context: { slug: data.Slug },
+      path: `/sectors/${data.slug}`,
+      component: path.resolve(`./src/pages/organizations.js`),
+      context: {
+        sectorName: data.name,
+        slugRegex: `/${data.slug}/`,
+      },
     })
   })
 

--- a/src/components/OrganizationAttributes.js
+++ b/src/components/OrganizationAttributes.js
@@ -1,7 +1,13 @@
 import React from "react"
 import Tag from "./Tag"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faUsers, faBuilding, faLocationArrow, faTag } from '@fortawesome/free-solid-svg-icons'
+import { faBox, faUsers, faBuilding, faLocationArrow, faTag } from '@fortawesome/free-solid-svg-icons'
+
+export const OrganizationSector = ({ text, ...props }) => (
+  <Tag
+      { ...props }
+    ><FontAwesomeIcon icon={faBox} className="mr-1" />{text}</Tag>
+)
 
 export const OrganizationTag = ({ text, ...props }) => (
   <Tag
@@ -20,10 +26,9 @@ export const OrganizationHeadcount = ({ text, ...props }) => (
         { ...props }
       ><FontAwesomeIcon icon={faUsers} className="mr-1" />{text}</Tag>
   )
-  
+
 export const OrganizationOrgType = ({ text, ...props }) => (
     <Tag
         { ...props }
       ><FontAwesomeIcon icon={faBuilding} className="mr-1" />{text}</Tag>
   )
-  

--- a/src/components/OrganizationCard.js
+++ b/src/components/OrganizationCard.js
@@ -3,11 +3,11 @@ import { Link } from "gatsby"
 import Img from "gatsby-image"
 import PropTypes from "prop-types"
 
-import { OrganizationTag, OrganizationLocation, OrganizationHeadcount, OrganizationOrgType } from "../components/OrganizationAttributes"
+import { OrganizationSector, OrganizationTag, OrganizationLocation, OrganizationHeadcount, OrganizationOrgType } from "../components/OrganizationAttributes"
 
 import "./OrganizationCard.css"
 
-const OrganizationCard = ({ title, description, tags, slug, homepage, location, logo, headcount, orgType, currentFilter, onApplyFilter }) => (
+const OrganizationCard = ({ title, description, tags, slug, homepage, location, logo, sector, showSector, headcount, orgType, currentFilter, onApplyFilter }) => (
   <div className="OrganizationCard flex items-center border-b border-gray-400 p-3 text-gray-900">
     <div className="mr-5 w-16 flex-shrink-0 hidden sm:block">
     {logo &&
@@ -17,10 +17,14 @@ const OrganizationCard = ({ title, description, tags, slug, homepage, location, 
     <div>
       <p>
         <Link to={`/organizations/${slug}`} className="font-bold hover:text-teal-500 mr-2">{title}</Link>
-
         {description}
       </p>
       <div className="mt-1">
+        {sector && showSector &&
+          <OrganizationSector
+            onClick={e => onApplyFilter.bySector(sector)}
+            active={currentFilter.bySector && sector.slug === currentFilter.bySector.slug}
+            text={sector.name} />}
         {
           tags && tags.map((tag, i) =>
             <OrganizationTag
@@ -70,6 +74,10 @@ OrganizationCard.propTypes = {
   homepage: PropTypes.string,
   location: PropTypes.string,
   logo: PropTypes.object,
+  sector: PropTypes.shape({
+    name: PropTypes.string,
+    slug: PropTypes.string,
+  }),
   headcount: PropTypes.string,
   orgType: PropTypes.string,
   currentFilter: PropTypes.object,

--- a/src/components/OrganizationFilter.js
+++ b/src/components/OrganizationFilter.js
@@ -1,18 +1,21 @@
 import React, {useState} from "react"
-import { OrganizationTag, OrganizationLocation, OrganizationHeadcount, OrganizationOrgType } from "../components/OrganizationAttributes"
+import { OrganizationSector, OrganizationTag, OrganizationLocation, OrganizationHeadcount, OrganizationOrgType } from "../components/OrganizationAttributes"
 
 export const useOrganizationFilterState = () => {
+    const [bySector, setSectorFilter] = useState(null);
     const [byTag, setTagFilter] = useState(null);
     const [byLocation, setLocationFilter] = useState(null);
     const [byHeadcount, setHeadcountFilter] = useState(null);
     const [byOrgType, setOrgTypeFilter] = useState(null);
-  
-    const setFilter = { 
+
+    const setFilter = {
+      bySector: setSectorFilter,
       byTag: setTagFilter,
       byLocation: setLocationFilter,
       byHeadcount: setHeadcountFilter,
       byOrgType: setOrgTypeFilter,
       none: () => {
+        setSectorFilter(null);
         setTagFilter(null);
         setLocationFilter(null);
         setHeadcountFilter(null);
@@ -21,30 +24,37 @@ export const useOrganizationFilterState = () => {
     };
 
     const applyFilter = organizations => {
+        if (bySector)
+          organizations = organizations.filter(org => (org.sector && org.sector.slug) === bySector.slug);
+
         if (byTag)
-            organizations = organizations.filter(org => org.tags && org.tags.indexOf(byTag) >= 0);
-    
+          organizations = organizations.filter(org => org.tags && org.tags.indexOf(byTag) >= 0);
+
         if (byLocation)
-            organizations = organizations.filter(org => org.location === byLocation);
+          organizations = organizations.filter(org => org.location === byLocation);
 
         if (byHeadcount)
-            organizations = organizations.filter(org => org.headcount === byHeadcount);
+          organizations = organizations.filter(org => org.headcount === byHeadcount);
 
         if (byOrgType)
-            organizations = organizations.filter(org => org.orgType === byOrgType);
+          organizations = organizations.filter(org => org.orgType === byOrgType);
+
         return organizations;
     }
 
-    return [{byTag, byLocation, byHeadcount, byOrgType }, setFilter, applyFilter];
+    return [{bySector, byTag, byLocation, byHeadcount, byOrgType }, setFilter, applyFilter];
   }
-  
+
 const OrganizationFilter = ({currentFilter, onClearFilter}) => {
-    const {byTag, byLocation, byHeadcount, byOrgType } = currentFilter;
-    const hasFilterApplied = (byTag || byLocation || byHeadcount || byOrgType) ;
+    const {bySector, byTag, byLocation, byHeadcount, byOrgType } = currentFilter;
+    const hasFilterApplied = (bySector || byTag || byLocation || byHeadcount || byOrgType) ;
     return (<>
     { hasFilterApplied && <p className="p-3 text-gray-700 bg-gray-100 border-b border-gray-400 text-sm">
     <span className="mr-2">Filtered by</span>
-    { byTag && 
+    { bySector &&
+      <OrganizationSector active={true} text={bySector.name} />
+    }
+    { byTag &&
       <OrganizationTag active={true} text={byTag} />
     }
     { byLocation &&


### PR DESCRIPTION
Related to #41 

**WIP** - not production ready

Create a page listing all organizations so that we can filter without being limited to one sector.

- [x] Create an `organizations` page
- [x] Getting rid of `sectors` template in favor of the new `organizations` page
- [ ] Add a link to `/organizations` somewhere (front page?)
----

Notes:

At first I was loading all the records and the front was doing the filtering based on the sector slug in the url but this was causing strong performance issues.
So I opted for filtering the organizations in the grahql (as before) using a regex trick.

This way when reaching via `/organizations`, the regex is empty and returns all the results and when coming from a `/sectors/water` the regex will be `/water/` and returns the organizations belonging to this sector.
I'm using a regex because with a string, sending and empty string on `/organizations` causes no result to be returned with the `eq` operator.
If you know a better approach, let me know :v:

The loading of the `/organizations` page is too slow. We should consider to implement an infinite scroll or something to ensure we don't load all records at once.