### PR TITLE
Add support for dotenv configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@ helping out. Simply fill out the [Climatescape Contributor Application][contribu
     $ npm install
     ```
 2. Copy your Airtable API key from this page: [Airtable account][airtable-account]
-3. Run the project like so, replacing `YOUR_KEY_HERE` the key you copied in the
-    previous step:
+3. Create a `.env.development` and a `.env.production` file at the root of the project
+   replacing `YOUR_KEY_HERE` by the key you copied in the previous step:
     ```bash
-    $ AIRTABLE_API_KEY=YOUR_KEY_HERE npm run develop
+    $ echo "AIRTABLE_API_KEY=YOUR_KEY_HERE" > .env.development && echo "AIRTABLE_API_KEY=YOUR_KEY_HERE" > .env.production
+    ```
+4. Run the project like so:
+    ```bash
+    $ npm run develop
     ```
 
 ## Architecture

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,7 @@
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
 module.exports = {
   siteMetadata: {
     title: `Climatescape`,


### PR DESCRIPTION
Following the setup defined on the [gatsby website doc](https://www.gatsbyjs.org/docs/environment-variables/#server-side-nodejs)

Define two files:
  - `.env.development` (used by `gatsby develop`)
  - `.env.production` (used by `gatsby build`)

they both contain the following:

`AIRTABLE_API_KEY=YOUR_API_KEY`

This allows:

```diff
- AIRTABLE_API_KEY=XXX npm run develop
+ npm run develop
```

which is better for your command history :wink:

----

I tested and it still work if you have no `.env.*` file and still use the `AIRTABLE_API_KEY=XXX ...`. So not a breaking change.