### PR TITLE
Create CTA for add missing organization

### DIFF
--- a/src/components/AddOrganizationCTA.js
+++ b/src/components/AddOrganizationCTA.js
@@ -1,0 +1,27 @@
+import React from "react"
+import PropTypes from "prop-types"
+import { Link } from 'gatsby'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPlusCircle } from '@fortawesome/free-solid-svg-icons'
+
+const VARIANTS = { simple: "simple", detailed: "detailed" }
+
+const AddOrganizationCTA = ({ variant = VARIANTS.detailed, text = "Add a missing organization" }) => {
+  const className = variant === VARIANTS.detailed ? "display-block" : "text-sm align-middle"
+
+  return (
+    <>
+      {variant === VARIANTS.detailed && <div>If you know any organizations solving climate change, we would love to have your recommendation.</div>}
+      <span className={`${className} text-gray-600 hover:text-teal-500 ml-3 whitespace-no-wrap`}>
+        <Link to="/contribute"><FontAwesomeIcon icon={faPlusCircle} className="mr-2" />{text}</Link>
+      </span>
+    </>
+  )
+}
+
+AddOrganizationCTA.propTypes = {
+  variant: PropTypes.string,
+  text: PropTypes.string,
+}
+
+export default AddOrganizationCTA

--- a/src/templates/sector.js
+++ b/src/templates/sector.js
@@ -6,6 +6,7 @@ import { stringCompare } from "../utils/string"
 import Layout from "../components/layout"
 import OrganizationCard from "../components/OrganizationCard"
 import OrganizationFilter, {useOrganizationFilterState} from "../components/OrganizationFilter"
+import AddOrganizationCTA from "../components/AddOrganizationCTA"
 import SEO from "../components/seo"
 
 const SectorTemplate = ({ data }) => {
@@ -39,7 +40,7 @@ const SectorTemplate = ({ data }) => {
 
     <div className="max-w-4xl mx-auto pb-4">
       <h2 className="text-3xl tracking-wide font-light p-3 md:mt-4">
-        {name} organizations
+        {name} organizations <AddOrganizationCTA variant="simple"/>
       </h2>
 
       <OrganizationFilter
@@ -64,6 +65,9 @@ const SectorTemplate = ({ data }) => {
             />
           )
         }
+      </div>
+      <div className="bg-white mt-8 p-3 text-center border-b border-gray-400">
+        <AddOrganizationCTA/>
       </div>
     </div>
   </Layout>


### PR DESCRIPTION
Related to #42 

Create a CTA (link) for adding a missing organization.
This link is pointing to our `/contribute` page where the "Submit an Organization" form is located.

Here is the result, any feedback on the UI is appreciated :see_no_evil: 

----

![localhost_8000_sectors_carbon_ (1)](https://user-images.githubusercontent.com/1302282/73855622-9bf14100-4834-11ea-9491-350c93a1debc.png)

----

**Note:**
I had a quick overview of the form embeds via Airtable and I don't think we can prefill any fields (I might be wrong).
