### PR TITLE
Import fortawesome css

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -6,6 +6,8 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
     './src/**/*.js',
   ],
 
+  whitelistPatterns: [/svg-inline/],
+
   // Include any special characters you're using in this regular expression
   defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
 })

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -5,4 +5,6 @@
 
 @import "../styles/global.css";
 
+@import "../../node_modules/@fortawesome/fontawesome-svg-core/styles.css";
+
 @tailwind utilities;


### PR DESCRIPTION
This is a first attempt at fixing #49 

The root issue is that fortawesome/fontawesome's core styles are not in the initial HTML file, which means that the styling is only applied on hydration.