### PR TITLE
Use new Airtable base

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -23,14 +23,14 @@ module.exports = {
         apiKey: process.env.AIRTABLE_API_KEY,
         tables: [
           {
-            baseId: `appXCd5jCvXVSxDcZ`,
+            baseId: `appNYMWxGF1jMaf5V`,
             tableName: `Organizations`,
             tableView: `Published`,
             mapping: { "Published": `boolean`, "Logo": `fileNode` },
             tableLinks: [`Sector`]
           },
           {
-            baseId: `appXCd5jCvXVSxDcZ`,
+            baseId: `appNYMWxGF1jMaf5V`,
             tableName: `Sectors`,
             tableView: `Published`,
             mapping: { "Cover": `fileNode` },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,6 +6,8 @@
 
 const path = require(`path`)
 
+const makeSlug = require(`./src/utils/slug`).makeSlug
+
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions
 
@@ -22,7 +24,8 @@ exports.createPages = async ({ graphql, actions }) => {
       organizations: allAirtable(filter: {table: {eq: "Organizations"}}) {
         nodes {
           data {
-            Slug
+            ID
+            Name
           }
         }
       }
@@ -44,9 +47,9 @@ exports.createPages = async ({ graphql, actions }) => {
   // Create the organizations pages
   data.organizations.nodes.forEach(({ data }) => {
     createPage({
-      path: `/organizations/${data.Slug}`,
+      path: `/organizations/${makeSlug(data.Name)}`,
       component: path.resolve(`./src/templates/organization.js`),
-      context: { slug: data.Slug },
+      context: { id: data.ID },
     })
   })
 }

--- a/src/components/TopicCard.js
+++ b/src/components/TopicCard.js
@@ -2,7 +2,7 @@ import React from "react"
 import { Link } from "gatsby"
 import Img from "gatsby-image"
 
-const TopicCard = ({ title, count, img, path }) => (
+const TopicCard = ({ title, img, path }) => (
   <div className="w-full sm:w-1/2 md:w-1/4 p-3">
     <Link to={path}  className="block rounded overflow-hidden shadow-md relative">
       <Img fluid={img} className="w-full h-40 object-cover" />

--- a/src/pages/contribute.js
+++ b/src/pages/contribute.js
@@ -24,7 +24,7 @@ const ContributePage = () => (
         </p>
       </div>
       <div className="lg:w-3/5 border-gray-300 lg:border-r">
-        <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></script><iframe title="Public Submission Form" className="airtable-embed airtable-dynamic-height" src="https://airtable.com/embed/shrVmZ8nPOrVuCPEh?backgroundColor=purple" frameBorder="0" onmousewheel="" width="100%" height="922" style={{ background: "transparent" }}></iframe>
+        <iframe title="Public Submission Form" className="airtable-embed" src="https://airtable.com/embed/shrWzh6qSX3wHXM9a?backgroundColor=teal" frameBorder="0" onmousewheel="" width="100%" height="1150" style={{ background: "transparent" }}></iframe>
       </div>
     </div>
   </Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,7 +20,6 @@ const IndexPage = () => {
         nodes {
           data {
             Name
-            Organizations_Count
             Slug
             Cover {
               localFiles {
@@ -57,7 +56,6 @@ const IndexPage = () => {
           sectors.map((node, index) =>
             <TopicCard
               title={node.data.Name}
-              count={node.data.Organizations_Count}
               img={node.data.Cover.localFiles[0].childImageSharp.fluid}
               path={`/sectors/${node.data.Slug}`}
               key={index}

--- a/src/pages/organizations.js
+++ b/src/pages/organizations.js
@@ -2,7 +2,7 @@ import React from "react"
 import { graphql } from 'gatsby'
 
 import { stringCompare } from "../utils/string"
-import { filterDuplicateAndEmptyItems } from "../utils/array"
+import { makeSlug } from "../utils/slug"
 
 import Layout from "../components/layout"
 import OrganizationCard from "../components/OrganizationCard"
@@ -17,14 +17,14 @@ const OrganizationsTemplate = ({ data, pageContext }) => {
   // Avoid breaking if the sector has no orgs + map out nested data object
   let organizations = (data.organizations.nodes || [])
     .map(o => o.data)
-    .map(({ Name, About, Tags, Slug, Homepage, City, State_Province, Country, Tagline, Logo, Headcount, Organization_Type, Sector }) => ({
+    .map(({ Name, About, Tags, Homepage, HQ_Location, Tagline, Logo, Headcount, Organization_Type, Sector }) => ({
       title: Name,
       description: Tagline || About,
       tags: Tags,
-      location: filterDuplicateAndEmptyItems(City, State_Province, Country).join(', '),
+      location: HQ_Location,
       headcount: Headcount,
       orgType: Organization_Type,
-      slug: Slug,
+      slug: makeSlug(Name),
       homepage: Homepage,
       logo: Logo?.localFiles?.[0]?.childImageSharp?.fixed,
       sector: sectors.find(sector => sector.slug === Sector?.[0]?.data?.Slug),
@@ -84,12 +84,9 @@ export const query = graphql`
           Name
           Homepage
           About
-          Slug
           Tags,
           Tagline,
-          City,
-          State_Province,
-          Country,
+          HQ_Location,
           Organization_Type,
           Headcount,
           Logo {

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -13,7 +13,7 @@ const OrganizationTemplate = ({ data }) => {
   const siteTitle = data.site.siteMetadata.title
   const orgData = data.airtable.data
 
-  const sector = orgData.Sector[0]?.data || {}
+  const sector = (orgData.Sector && orgData.Sector[0]?.data) || {}
   const org = {
     logo: orgData.Logo?.localFiles?.[0]?.childImageSharp?.fixed,
     title: orgData.Name,

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -9,8 +9,6 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 import Section from "../components/Section"
 
-import { filterDuplicateAndEmptyItems } from "../utils/array"
-
 const OrganizationTemplate = ({ data }) => {
   const siteTitle = data.site.siteMetadata.title
   const orgData = data.airtable.data
@@ -25,7 +23,7 @@ const OrganizationTemplate = ({ data }) => {
     },
     tagline: orgData.Tagline,
     about: orgData.About && orgData.About.replace(orgData.Tagline, ""),
-    location: filterDuplicateAndEmptyItems(orgData.City, orgData.State_Province, orgData.Country).join(", "),
+    location: orgData.HQ_Location,
     headcount: orgData.Headcount,
     orgType: orgData.Organization_Type,
     homepage: orgData.Homepage,
@@ -73,14 +71,14 @@ const OrganizationTemplate = ({ data }) => {
 }
 
 export const query = graphql`
-  query OrganizationPageQuery($slug: String) {
+  query OrganizationPageQuery($id: Int) {
     site {
       siteMetadata {
         title
       }
     }
 
-    airtable(table: { eq: "Organizations" }, data: { Slug: { eq: $slug } }) {
+    airtable(table: { eq: "Organizations" }, data: { ID: { eq: $id } }) {
       data {
         Logo {
           localFiles {
@@ -100,9 +98,7 @@ export const query = graphql`
         }
         Tagline
         About
-        City
-        State_Province
-        Country
+        HQ_Location
         Headcount
         Organization_Type
         Homepage

--- a/src/utils/slug.js
+++ b/src/utils/slug.js
@@ -1,0 +1,4 @@
+// Convert a string to a URL-friendly slug
+module.exports.makeSlug = function (string) {
+  return string.toLowerCase().replace('&', 'and').replace(/[^\w\- ]/g, '').replace(/ +/g, '-')
+}


### PR DESCRIPTION
This PR moves the site over to the new Airtable base. There are some minor changes to that base which required code updates:

* The new base doesn't have a "Slug" for organizations since it was not scalable to implement a robust formula to do this within Airtable.
* Organizations now have a single "HQ Location" string rather than separated City/Region/Country