### PR TITLE
Remove Photos

### DIFF
--- a/src/pages/organizations.js
+++ b/src/pages/organizations.js
@@ -101,20 +101,6 @@ export const query = graphql`
           HQ_Location
           Organization_Type
           Headcount
-          Photos {
-            localFiles {
-              childImageSharp {
-                fixed(
-                  width: 128
-                  height: 128
-                  fit: CONTAIN
-                  background: "white"
-                ) {
-                  ...GatsbyImageSharpFixed
-                }
-              }
-            }
-          }
           Categories {
             id
             data {
@@ -184,20 +170,6 @@ export const query = graphql`
           HQ_Location
           Organization_Type
           Headcount
-          Photos {
-            localFiles {
-              childImageSharp {
-                fixed(
-                  width: 128
-                  height: 128
-                  fit: CONTAIN
-                  background: "white"
-                ) {
-                  ...GatsbyImageSharpFixed
-                }
-              }
-            }
-          }
           Categories {
             id
             data {

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -154,18 +154,6 @@ export const query = graphql`
             }
           }
         }
-        Photos {
-          localFiles {
-            childImageSharp {
-              fluid(maxWidth: 700) {
-                ...GatsbyImageSharpFluid
-              }
-            }
-          }
-          internal {
-            content
-          }
-        }
         Categories {
           id
           data {


### PR DESCRIPTION
The builds are currently timing out with all of the photos.

We setup netlify caching today, but it currently crashes trying to hash all of the files. By temporarily removing Photos while we wait on them to fix the issue we should be able to resume building and later re-add it.

https://github.com/netlify/build/issues/1026
