### PR TITLE
Use fragments to DRY up GraphQL

### DIFF
--- a/src/components/OrganizationCard.js
+++ b/src/components/OrganizationCard.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Link } from "gatsby"
+import { Link, graphql } from "gatsby"
 import Img from "gatsby-image"
 import PropTypes from "prop-types"
 
@@ -20,7 +20,7 @@ function getLogoImage({ logo, photos, categories }) {
   return logo || photos[0] || cat?.cover || cat?.parent.cover
 }
 
-function OrganizationCard({
+export default function OrganizationCard({
   pageContext,
   organization,
   currentFilter,
@@ -146,4 +146,70 @@ OrganizationCard.propTypes = {
   onApplyFilter: PropTypes.object,
 }
 
-export default OrganizationCard
+// Includes all the expected attributes for rendering an OrganizationCard. To
+// query Capital Profile information, use the CapitalOrganizationCard fragment
+export const query = graphql`
+  fragment OrganizationCardLogo on AirtableField {
+    localFiles {
+      childImageSharp {
+        fixed(
+          width: 128
+          height: 128
+          fit: CONTAIN
+          background: "white"
+        ) {
+          ...GatsbyImageSharpFixed
+        }
+      }
+    }
+  }
+
+  fragment OrganizationCard on Airtable {
+    data {
+      Name
+      Homepage
+      About
+      Tags
+      Tagline
+      HQ_Location
+      Organization_Type
+      Headcount
+      Categories {
+        id
+        data {
+          Name
+          Parent {
+            id
+            data {
+              Name
+            }
+          }
+        }
+      }
+      Logo {
+        ...OrganizationCardLogo
+      }
+      LinkedIn_Profiles {
+        data {
+          Logo {
+            ...OrganizationCardLogo
+          }
+        }
+      }
+    }
+  }
+
+  fragment CapitalOrganizationCard on Airtable {
+    ...OrganizationCard
+    data {
+      Capital_Profile {
+        data {
+          Type
+          Strategic
+          Stage
+          CheckSize: Check_Size
+        }
+      }
+    }
+  }
+`

--- a/src/components/OrganizationCard.js
+++ b/src/components/OrganizationCard.js
@@ -152,12 +152,7 @@ export const query = graphql`
   fragment OrganizationCardLogo on AirtableField {
     localFiles {
       childImageSharp {
-        fixed(
-          width: 128
-          height: 128
-          fit: CONTAIN
-          background: "white"
-        ) {
+        fixed(width: 128, height: 128, fit: CONTAIN, background: "white") {
           ...GatsbyImageSharpFixed
         }
       }

--- a/src/pages/capital.js
+++ b/src/pages/capital.js
@@ -75,66 +75,7 @@ export const query = graphql`
       }
     ) {
       nodes {
-        data {
-          Name
-          Homepage
-          About
-          Tagline
-          HQ_Location
-          Organization_Type
-          Logo {
-            localFiles {
-              childImageSharp {
-                fixed(
-                  width: 64
-                  height: 64
-                  fit: CONTAIN
-                  background: "white"
-                ) {
-                  ...GatsbyImageSharpFixed
-                }
-              }
-            }
-          }
-          Categories {
-            id
-            data {
-              Name
-              Parent {
-                id
-                data {
-                  Name
-                }
-              }
-            }
-          }
-          Capital_Profile {
-            data {
-              Type
-              Strategic
-              Stage
-              CheckSize: Check_Size
-            }
-          }
-          LinkedIn_Profiles {
-            data {
-              Logo {
-                localFiles {
-                  childImageSharp {
-                    fixed(
-                      width: 64
-                      height: 64
-                      fit: CONTAIN
-                      background: "white"
-                    ) {
-                      ...GatsbyImageSharpFixed
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+        ...CapitalOrganizationCard
       }
     }
     site {

--- a/src/pages/organizations.js
+++ b/src/pages/organizations.js
@@ -92,60 +92,7 @@ export const query = graphql`
       }
     ) {
       nodes {
-        data {
-          Name
-          Homepage
-          About
-          Tags
-          Tagline
-          HQ_Location
-          Organization_Type
-          Headcount
-          Categories {
-            id
-            data {
-              Name
-              Parent {
-                id
-                data {
-                  Name
-                }
-              }
-            }
-          }
-          Logo {
-            localFiles {
-              childImageSharp {
-                fixed(
-                  width: 128
-                  height: 128
-                  fit: CONTAIN
-                  background: "white"
-                ) {
-                  ...GatsbyImageSharpFixed
-                }
-              }
-            }
-          }
-          LinkedIn_Profiles {
-            data {
-              Logo {
-                localFiles {
-                  childImageSharp {
-                    fixed(
-                      width: 128
-                      height: 128
-                      fit: CONTAIN
-                      background: "white"
-                    ) {
-                      ...GatsbyImageSharpFixed
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+        ...OrganizationCard
       }
     }
     subOrganizations: allAirtable(
@@ -161,55 +108,7 @@ export const query = graphql`
       }
     ) {
       nodes {
-        data {
-          Name
-          Homepage
-          About
-          Tags
-          Tagline
-          HQ_Location
-          Organization_Type
-          Headcount
-          Categories {
-            id
-            data {
-              Name
-              Parent {
-                id
-                data {
-                  Name
-                }
-              }
-            }
-          }
-          Logo {
-            localFiles {
-              childImageSharp {
-                fixed(
-                  width: 128
-                  height: 128
-                  fit: CONTAIN
-                  background: "white"
-                ) {
-                  ...GatsbyImageSharpFixed
-                }
-              }
-            }
-          }
-          LinkedIn_Profiles {
-            data {
-              Logo {
-                localFiles {
-                  childImageSharp {
-                    fixed(width: 128, height: 128, fit: CONTAIN) {
-                      ...GatsbyImageSharpFixed
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+        ...OrganizationCard
       }
     }
   }


### PR DESCRIPTION
Using fragments in our `OrganizationCard` component to reduce duplication across areas of the site that use it. Fixes #118 