### PR TITLE
Separates capital-only orgs from others

### DIFF
--- a/src/pages/organizations.js
+++ b/src/pages/organizations.js
@@ -89,7 +89,14 @@ export const query = graphql`
       filter: {
         table: { eq: "Organizations" }
         data: {
-          Role: { in: ["Products & Services", "Research & Development", "Advocacy", "Network"] }
+          Role: {
+            in: [
+              "Products & Services"
+              "Research & Development"
+              "Advocacy"
+              "Network"
+            ]
+          }
           Categories: { elemMatch: { id: { eq: $categoryId } } }
         }
       }
@@ -155,7 +162,14 @@ export const query = graphql`
       filter: {
         table: { eq: "Organizations" }
         data: {
-          Role: { in: ["Products & Services", "Research & Development", "Advocacy", "Network"] }
+          Role: {
+            in: [
+              "Products & Services"
+              "Research & Development"
+              "Advocacy"
+              "Network"
+            ]
+          }
           Categories: {
             elemMatch: {
               data: { Parent: { elemMatch: { id: { eq: $categoryId } } } }

--- a/src/pages/organizations.js
+++ b/src/pages/organizations.js
@@ -88,7 +88,10 @@ export const query = graphql`
     topOrganizations: allAirtable(
       filter: {
         table: { eq: "Organizations" }
-        data: { Categories: { elemMatch: { id: { eq: $categoryId } } } }
+        data: {
+          Role: { in: ["Products & Services", "Research & Development", "Advocacy", "Network"] }
+          Categories: { elemMatch: { id: { eq: $categoryId } } }
+        }
       }
     ) {
       nodes {
@@ -152,6 +155,7 @@ export const query = graphql`
       filter: {
         table: { eq: "Organizations" }
         data: {
+          Role: { in: ["Products & Services", "Research & Development", "Advocacy", "Network"] }
           Categories: {
             elemMatch: {
               data: { Parent: { elemMatch: { id: { eq: $categoryId } } } }


### PR DESCRIPTION
Capital orgs tend to dominate other orgs because they cover so many categories. Now that we have a dedicated "Capital" section, we can remove these orgs from our primary organizations list. Fixes #116 