### PR TITLE
Make the "no results" message in the search bar visible

### DIFF
--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -30,7 +30,15 @@ const hitComps = { PageHit }
 
 const Results = connectStateResults(
   ({ searchState: state, searchResults: res, children }) =>
-    res && res.nbHits > 0 ? children : `No results for '${state.query}'`
+    res && res.nbHits > 0 ? (
+      children
+    ) : (
+      <div className="no-results text-gray-700">
+        <span>
+          No results found for <span className="highlight">{state.query}</span>
+        </span>
+      </div>
+    )
 )
 
 const useClickOutside = (ref, handler, events) => {

--- a/src/components/search/styles.css
+++ b/src/components/search/styles.css
@@ -16,7 +16,7 @@
 }
 
 .algolia-bar {
-   @apply leading-8 text-left inline-block pl-4 bg-gray-200 rounded-b-sm;
+  @apply leading-8 text-left inline-block pl-4 bg-gray-200 rounded-b-sm;
 }
 
 .algolia-bar span {
@@ -29,4 +29,12 @@
 
 .search-root .hit a {
   @apply flex-grow;
+}
+
+.no-results span {
+  @apply pl-4 leading-8;
+}
+
+.no-results .highlight {
+  @apply pl-0 font-bold;
 }


### PR DESCRIPTION
Issue #74 

This was a CSS issue. I formatted the results message in a `div` and a few `span` tags and made the styling consistent with the regular search result containers.
