### PR TITLE
Use Netlify for organization photos

### DIFF
--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -74,7 +74,10 @@ function Tags({ org }) {
 
 export default function OrganizationTemplate({ data }) {
   const siteTitle = data.site.siteMetadata.title
-  const org = transformOrganization(data.organization)
+  const org = transformOrganization(data.organization, (raw, out) => ({
+    ...out,
+    fullPhotos: raw.data.fullPhotos?.localFiles || []
+  }))
 
   const img = getLogoImage(org)
 
@@ -96,15 +99,15 @@ export default function OrganizationTemplate({ data }) {
               </div>
               <div>
                 <h1 className="flex-grow text-xl font-semibold">{org.title}</h1>
-                <p> {org.description}</p>
+                <p>{org.description}</p>
               </div>
             </div>
             <Tags org={org} />
 
-            {org.thumbnails[0] && (
+            {org.fullPhotos[0] && (
               <div className="carousel my-8 bg-gray-200 rounded-lg p-4">
                 <img
-                  src={org.thumbnails[0].url}
+                  src={org.fullPhotos[0].publicURL}
                   alt={org.title}
                   style={{ height: "20rem" }}
                   className="organization-img mx-auto"
@@ -173,6 +176,11 @@ export const query = graphql`
         }
         Photos {
           ...OrganizationCardPhoto
+        }
+        fullPhotos: Photos {
+          localFiles {
+            publicURL
+          }
         }
         LinkedIn_Profiles {
           data {

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -76,7 +76,7 @@ export default function OrganizationTemplate({ data }) {
   const siteTitle = data.site.siteMetadata.title
   const org = transformOrganization(data.organization, (raw, out) => ({
     ...out,
-    fullPhotos: raw.data.fullPhotos?.localFiles || []
+    fullPhotos: raw.data.fullPhotos?.localFiles || [],
   }))
 
   const img = getLogoImage(org)

--- a/src/utils/airtable.js
+++ b/src/utils/airtable.js
@@ -57,7 +57,7 @@ function transformThumbnails(Photos) {
 // simplifies data structures.
 // Optionally accepts a `userTransform` function to further modify the `out`
 // value with `raw` data before returning
-export function transformOrganization(raw, userTransform = (raw, out) => out) {
+export function transformOrganization(raw, userTransform = (_, out) => out) {
   const {
     id,
     data: {
@@ -105,7 +105,7 @@ export function transformOrganization(raw, userTransform = (raw, out) => out) {
       Photos?.localFiles
         ?.map(i => i.childImageSharp)
         .map(i => i.resize || i.fixed || i.fluid) || [],
-    thumbnails: transformThumbnails(Photos)
+    thumbnails: transformThumbnails(Photos),
   })
 }
 

--- a/src/utils/airtable.js
+++ b/src/utils/airtable.js
@@ -53,27 +53,33 @@ function transformThumbnails(Photos) {
     : []
 }
 
-export function transformOrganization({
-  id,
-  data: {
-    Name,
-    About,
-    Tags,
-    Homepage,
-    HQ_Location: HQLocation,
-    Tagline,
-    Logo,
-    LinkedIn,
-    LinkedIn_Profiles: LinkedinProfile,
-    Headcount,
-    Organization_Type: OrganizationType,
-    Categories,
-    Twitter,
-    Capital_Profile: CapitalProfile,
-    Photos,
-  },
-}) {
-  return {
+// Accepts a `raw` organization from GraphQL, cleans up the key formatting and
+// simplifies data structures.
+// Optionally accepts a `userTransform` function to further modify the `out`
+// value with `raw` data before returning
+export function transformOrganization(raw, userTransform = (raw, out) => out) {
+  const {
+    id,
+    data: {
+      Name,
+      About,
+      Tags,
+      Homepage,
+      HQ_Location: HQLocation,
+      Tagline,
+      Logo,
+      LinkedIn,
+      LinkedIn_Profiles: LinkedinProfile,
+      Headcount,
+      Organization_Type: OrganizationType,
+      Categories,
+      Twitter,
+      Capital_Profile: CapitalProfile,
+      Photos,
+    },
+  } = raw
+
+  return userTransform(raw, {
     id,
     title: Name,
     description: Tagline || About,
@@ -99,13 +105,13 @@ export function transformOrganization({
       Photos?.localFiles
         ?.map(i => i.childImageSharp)
         .map(i => i.resize || i.fixed || i.fluid) || [],
-    thumbnails: transformThumbnails(Photos),
-  }
+    thumbnails: transformThumbnails(Photos)
+  })
 }
 
 export function transformOrganizations(orgs) {
   const organizations = orgs
-    .map(transformOrganization)
+    .map(org => transformOrganization(org))
     .sort((a, b) => stringCompare(a.title, b.title))
 
   if (typeof window === "object") {


### PR DESCRIPTION
We're not supposed to embed photos directly from Airtable. My privacy-heavy Firefox config also prevented these from loading at all.

This PR uses the same full-size photos but loads them from our domain on Netlify instead of Airtable.

I ended up extended the `transformOrganization` helper along the way to allow for caller-specific transforms to be applied.