### PR TITLE
Filter out empty orgs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -49,11 +49,13 @@ exports.createPages = async ({ graphql, actions }) => {
     })
 
   // Create the organizations pages
-  data.organizations.nodes.forEach(org => {
-    createPage({
-      path: `/organizations/${makeSlug(org.data.Name)}`,
-      component: path.resolve(`./src/templates/organization.js`),
-      context: { id: org.id },
+  data.organizations.nodes
+    .filter(({ data: { Name, Homepage } }) => Name && Homepage)
+    .forEach(org => {
+      createPage({
+        path: `/organizations/${makeSlug(org.data.Name)}`,
+        component: path.resolve(`./src/templates/organization.js`),
+        context: { id: org.id },
+      })
     })
-  })
 }

--- a/src/pages/capital.js
+++ b/src/pages/capital.js
@@ -61,7 +61,11 @@ export const query = graphql`
     organizations: allAirtable(
       filter: {
         table: { eq: "Organizations" }
-        data: { Role: { eq: "Capital" } }
+        data: {
+          Name: { ne: null }
+          Homepage: { ne: null }
+          Role: { eq: "Capital" }
+        }
       }
     ) {
       nodes {

--- a/src/pages/organizations.js
+++ b/src/pages/organizations.js
@@ -103,6 +103,8 @@ export const query = graphql`
               "Network"
             ]
           }
+          Name: { ne: null }
+          Homepage: { ne: null }
           Categories: { elemMatch: { id: { eq: $categoryId } } }
         }
       }
@@ -123,6 +125,8 @@ export const query = graphql`
               "Network"
             ]
           }
+          Name: { ne: null }
+          Homepage: { ne: null }
           Categories: {
             elemMatch: {
               data: { Parent: { elemMatch: { id: { eq: $categoryId } } } }


### PR DESCRIPTION
This prevents orgs from being empty.

NOTE: I have not tested this with an empty org. We'll probably want to add a *bad* 💀 org to airtable, trigger a build, and confirm it does not fail.

Fixes #158 