### PR TITLE
Allow for keyboard navigation of search results

### DIFF
--- a/src/components/search/styles.css
+++ b/src/components/search/styles.css
@@ -52,6 +52,11 @@
   }
 }
 
+.hits-wrapper .hit.selected,
+.hits-wrapper .selected mark {
+  background: #edf2f7;
+}
+
 .hits-wrapper li:first-child {
   border-top: none;
 }
@@ -63,8 +68,6 @@ li:first-child {
 .hits-wrapper li {
   line-height: 2em;
   border-top: 1px solid #efefef;
-  padding-left: 1rem;
-  padding-right: 1rem;
   text-align: left;
 }
 


### PR DESCRIPTION
Use up/down arrow to select a result in the list and enter to access it.
It also add a better display on mobile: the search wrapper takes the full window width

Fixes https://github.com/climatescape/climatescape.org/issues/67