### PR TITLE
Restyle Organization template and category tags

### DIFF
--- a/src/components/OrganizationAttributes.js
+++ b/src/components/OrganizationAttributes.js
@@ -14,28 +14,28 @@ import Tag from "./Tag"
 
 export const OrganizationCategory = ({ text, ...props }) => (
   <Tag {...props}>
-    <FontAwesomeIcon icon={faBox} className="mr-1" />
+    <FontAwesomeIcon icon={faBox} className="mr-2" />
     {text}
   </Tag>
 )
 
 export const OrganizationLocation = ({ text, ...props }) => (
   <Tag {...props}>
-    <FontAwesomeIcon icon={faLocationArrow} className="mr-1" />
+    <FontAwesomeIcon icon={faLocationArrow} className="mr-2" />
     {text}
   </Tag>
 )
 
 export const OrganizationHeadcount = ({ text, ...props }) => (
   <Tag {...props}>
-    <FontAwesomeIcon icon={faUsers} className="mr-1" />
+    <FontAwesomeIcon icon={faUsers} className="mr-2" />
     {text}
   </Tag>
 )
 
 export const OrganizationOrgType = ({ text, ...props }) => (
   <Tag {...props}>
-    <FontAwesomeIcon icon={faBuilding} className="mr-1" />
+    <FontAwesomeIcon icon={faBuilding} className="mr-2" />
     {text}
   </Tag>
 )

--- a/src/components/OrganizationCard.js
+++ b/src/components/OrganizationCard.js
@@ -49,7 +49,7 @@ export default function OrganizationCard({
 
   return (
     <div className="OrganizationCard border-gray-400 border-b flex items-center py-4 text-gray-900">
-      <div className="flex-grow self-start pr-8">
+      <div className="flex-grow self-center pr-8">
         <p>
           <Link to={slug} className="font-bold hover:text-teal-500 mr-2">
             {title}

--- a/src/components/SidebarSectionList.js
+++ b/src/components/SidebarSectionList.js
@@ -1,7 +1,13 @@
 import React from "react"
 import classnames from "classnames"
 
-const liClassName = "flex flex-row mt-3 font-medium text-sm text-gray-800"
+function Li({ children }) {
+  return (
+    <li className="flex flex-row mt-3 font-medium text-sm text-gray-800">
+      {children}
+    </li>
+  )
+}
 
 function Link({ icon, text, href, className }) {
   if (!href) {
@@ -9,7 +15,7 @@ function Link({ icon, text, href, className }) {
   }
 
   return (
-    <li className={liClassName}>
+    <Li>
       <a
         className={className ? classnames(className) : "flex underline"}
         href={href}
@@ -19,16 +25,19 @@ function Link({ icon, text, href, className }) {
         <div className="mr-3">{icon}</div>
         <span>{text}</span>
       </a>
-    </li>
+    </Li>
   )
 }
 
-function Item({ icon, text }) {
+function Item({ icon, text, hidden }) {
+  if (hidden) {
+    return null
+  }
   return (
-    <li className={liClassName}>
+    <Li>
       <div className="mr-3">{icon}</div>
       <span>{text}</span>
-    </li>
+    </Li>
   )
 }
 

--- a/src/components/SidebarSectionList.js
+++ b/src/components/SidebarSectionList.js
@@ -1,0 +1,50 @@
+import React from "react"
+import classnames from "classnames"
+
+const liClassName = "flex flex-row mt-3 font-medium text-sm text-gray-800"
+
+function Link({ icon, text, href, className }) {
+  if (!href) {
+    return null
+  }
+
+  return (
+    <li className={liClassName}>
+      <a
+        className={className ? classnames(className) : "flex underline"}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <div className="mr-3">{icon}</div>
+        <span>{text}</span>
+      </a>
+    </li>
+  )
+}
+
+function Item({ icon, text }) {
+  return (
+    <li className={liClassName}>
+      <div className="mr-3">{icon}</div>
+      <span>{text}</span>
+    </li>
+  )
+}
+
+/**
+ * Defines a section on the sidebar that is displayed as a list and have Item as children.
+ */
+function SidebarSectionList({ title, children, className }) {
+  return (
+    <div className={classnames(className)}>
+      {title && <div className="uppercase text-sm text-semibold">{title}</div>}
+      <ul>{children}</ul>
+    </div>
+  )
+}
+
+SidebarSectionList.Item = Item
+SidebarSectionList.Link = Link
+
+export default SidebarSectionList

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -2,7 +2,7 @@ import React from "react"
 
 const Tag = ({ children, active, onClick, ...otherProps }) => {
   let className =
-    "inline-block mt-1 bg-gray-200 hover:bg-gray-300 rounded-full px-2 py-1 text-xs font-semibold text-gray-600 mr-2"
+    "inline-block mt-1 px-2 py-1 text-xs rounded-full text-gray-700 mr-2"
 
   if (active) {
     className += " bg-gray-300"

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -48,7 +48,7 @@ function AttributesSection({ org }) {
     .concat(subCategories)
 
   return (
-    <SidebarSectionList title="In a snapshot" className="flex flex-col mb-12">
+    <SidebarSectionList title="In a snapshot" className="flex flex-col mb-8">
       {categoryList.map(category => (
         <SidebarSectionList.Item
           key={category.name}
@@ -56,31 +56,30 @@ function AttributesSection({ org }) {
           icon={<FontAwesomeIcon icon={faBox} />}
         />
       ))}
-      {org.location && (
+      {
         <SidebarSectionList.Item
           text={org.location}
           icon={<FontAwesomeIcon icon={faMapMarkerAlt} />}
+          hidden={!org.location}
         />
-      )}
-      {org.orgType && (
-        <SidebarSectionList.Item
-          text={org.orgType}
-          icon={<FontAwesomeIcon icon={faBuilding} />}
-        />
-      )}
-      {org.headcount && (
-        <SidebarSectionList.Item
-          text={`${org.headcount} employees`}
-          icon={<FontAwesomeIcon icon={faUsers} />}
-        />
-      )}
+      }
+      <SidebarSectionList.Item
+        text={org.orgType}
+        icon={<FontAwesomeIcon icon={faBuilding} />}
+        hidden={!org.orgType}
+      />
+      <SidebarSectionList.Item
+        text={`${org.headcount} employees`}
+        icon={<FontAwesomeIcon icon={faUsers} />}
+        hidden={!org.headcount}
+      />
     </SidebarSectionList>
   )
 }
 
-function SocialLinksSection({ org }) {
+function SocialLinksSection({ data, org }) {
   return (
-    <SidebarSectionList title="Links" className="flex flex-col mb-12">
+    <SidebarSectionList title="Links" className="flex flex-col mb-8">
       <SidebarSectionList.Link
         text="Homepage"
         href={org.homepage}
@@ -95,6 +94,11 @@ function SocialLinksSection({ org }) {
         text={parseTwitterPath(org.twitter)}
         href={buildUrl(org.twitter, "Twitter")}
         icon={<FontAwesomeIcon icon={faTwitter} />}
+      />
+      <SidebarSectionList.Link
+        href={getEditUrl({ data, org })}
+        text="Suggest an Edit"
+        icon={<FontAwesomeIcon icon={faEdit} />}
       />
     </SidebarSectionList>
   )
@@ -152,15 +156,7 @@ export default function OrganizationTemplate({ data }) {
           <div className="flex flex-col lg:w-2/5 items-center">
             <div className="flex flex-col">
               <AttributesSection org={org} />
-              <SocialLinksSection org={org} />
-              <SidebarSectionList>
-                <SidebarSectionList.Link
-                  href={getEditUrl({ data, org })}
-                  className="flex items-center text-center px-2 py-2 leading-none border rounded border-gray-700 text-sm hover:text-white hover:bg-teal-500"
-                  text="Suggest an Edit"
-                  icon={<FontAwesomeIcon icon={faEdit} />}
-                />
-              </SidebarSectionList>
+              <SocialLinksSection data={data} org={org} />
             </div>
           </div>
         </div>

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,0 +1,24 @@
+export function parseTwitterPath(url) {
+  if (!url) return null
+  if (url.startsWith("@")) return url
+  const displayName = new URL(url).pathname.substring(1)
+  return `@${displayName}`
+}
+
+export function buildUrl(url, network) {
+  if (!url) return null
+  try {
+    const address = new URL(url)
+    return address.href
+  } catch (err) {
+    if (url.startsWith("@")) {
+      url = url.substring(1)
+    }
+    switch (network) {
+      case "Twitter":
+        return `https://twitter.com/${url}`
+      default:
+        return url
+    }
+  }
+}


### PR DESCRIPTION
issue: #204 
Alongside with help from @loiclefloch, we made the Organisation template neater.
following the mocks, all the org attributes appear in a sidebar to the right and the links redesigned as well, the edit button went down to the end of the section.

The category tags in the organisations list is now background free followed by the mocks as well.

Please note that the page is not responsive yet, i think it's for another PR, but i don't plan working on it for now.