### PR TITLE
Fixes vertical scroll showing on mobile

### DIFF
--- a/src/components/search/input.js
+++ b/src/components/search/input.js
@@ -14,7 +14,9 @@ function Input({
   return (
     <input
       {...rest}
-      className="outline-none border-none bg-transparent text-gray-800 leading-8 font-title flex flex-grow placeholder-gray-800"
+      // w-full avoid having vertical scroll.
+      // overflow-hidden is a little bit tricky. Fixes the vertical scroll on Firefox.
+      className="w-full overflow-hidden outline-none border-none bg-transparent text-gray-800 leading-8 font-title flex flex-grow placeholder-gray-800"
     />
   )
 }


### PR DESCRIPTION
This fixes the vertical scroll appearing on mobile.
Maybe there is a better way to do it, but it works.
I honestly do not know why the `w-full` is enough for Chrome but not for Firefox (which I resolved using `overflow-hidden`).