### PR TITLE
Fix tagline/about issues

### DIFF
--- a/src/components/OrganizationCard.js
+++ b/src/components/OrganizationCard.js
@@ -19,12 +19,6 @@ function getLogoImage({ logo, photos, categories }) {
   return logo || photos[0] || cat?.cover || cat?.parent.cover
 }
 
-function truncateDescription(description) {
-  const offset = 30
-  const index = description?.slice(offset).search(/\./) ?? -1
-  return index === -1 ? description : description.substr(0, index + offset + 1)
-}
-
 export default function OrganizationCard({ pageContext, organization }) {
   const {
     title,
@@ -49,7 +43,7 @@ export default function OrganizationCard({ pageContext, organization }) {
           <Link to={slug} className="font-bold hover:text-teal-500 mr-2">
             {title}
           </Link>
-          {truncateDescription(description)}
+          {description}
         </p>
         <div className="mt-1">
           {capitalProfile?.type?.map(type => (

--- a/src/templates/organization.js
+++ b/src/templates/organization.js
@@ -168,7 +168,7 @@ export default function OrganizationTemplate({ data }) {
               </div>
               <div>
                 <h1 className="flex-grow text-xl font-semibold">{org.title}</h1>
-                <p>{org.description}</p>
+                <p>{org.tagline}</p>
               </div>
             </div>
 

--- a/src/utils/airtable.js
+++ b/src/utils/airtable.js
@@ -54,7 +54,7 @@ function transformThumbnails(Photos) {
     : []
 }
 
-const DescriptionRegexp = /([^\.]{2}\.)(?:\s|$)/
+const DescriptionRegexp = /([^.]{2}\.)(?:\s|$)/
 const DescriptionThreshold = 180
 
 function truncateDescription(string) {

--- a/src/utils/airtable.js
+++ b/src/utils/airtable.js
@@ -54,6 +54,23 @@ function transformThumbnails(Photos) {
     : []
 }
 
+const DescriptionThreshold = 180
+const DescriptionSentence = /(.+)+(?:\.\s)/
+
+function truncateDescription(string) {
+  if (!string) return null
+
+  // If the string is below the threshold, use it
+  if (string.length <= DescriptionThreshold) return string
+
+  // If the first sentences is below the threshold, use it
+  const firstSentence = string.match(DescriptionSentence)[1]
+  if (firstSentence?.length <= DescriptionThreshold) return firstSentence
+
+  // Otherwise truncate the full string and add an ellipsis
+  return `${string.substring(0, DescriptionThreshold)}…`
+}
+
 // Accepts a `raw` organization from GraphQL, cleans up the key formatting and
 // simplifies data structures.
 // Optionally accepts a `userTransform` function to further modify the `out`
@@ -87,7 +104,7 @@ export function transformOrganization(raw, userTransform = (_, out) => out) {
   return userTransform(raw, {
     id,
     title: Name,
-    description: Tagline || About,
+    description: truncateDescription(Tagline || About),
     tagline: Tagline,
     about: About || "",
     location: HQLocation,

--- a/src/utils/airtable.js
+++ b/src/utils/airtable.js
@@ -54,8 +54,8 @@ function transformThumbnails(Photos) {
     : []
 }
 
+const DescriptionRegexp = /([^\.]{2}\.)(?:\s|$)/
 const DescriptionThreshold = 180
-const DescriptionSentence = /(.+)+(?:\.\s)/
 
 function truncateDescription(string) {
   if (!string) return null
@@ -64,8 +64,10 @@ function truncateDescription(string) {
   if (string.length <= DescriptionThreshold) return string
 
   // If the first sentences is below the threshold, use it
-  const firstSentence = string.match(DescriptionSentence)[1]
-  if (firstSentence?.length <= DescriptionThreshold) return firstSentence
+  const sentencePieces = string.split(DescriptionRegexp, 2)
+  const sentence = sentencePieces.length === 2 && sentencePieces.join("")
+
+  if (sentence && sentence.length <= DescriptionThreshold) return sentence
 
   // Otherwise truncate the full string and add an ellipsis
   return `${string.substring(0, DescriptionThreshold)}…`


### PR DESCRIPTION
* On list pages, prefer Tagline, fall back to a truncated About
* On organization pages, use Tagline and About directly

Fixes #147 