### PR TITLE
use env AIRTABLE_BASE_ID property

### DIFF
--- a/backend/src/api/airtable.js
+++ b/backend/src/api/airtable.js
@@ -8,7 +8,7 @@ Airtable.configure({
   endpointUrl: "https://api.airtable.com",
   apiKey: process.env.AIRTABLE_API_KEY,
 })
-const airtableBase = Airtable.base("appNYMWxGF1jMaf5V")
+const airtableBase = Airtable.base(process.env.AIRTABLE_BASE_ID)
 
 /**
  * The rate limit is 5 rps, but we don't try to be even close to that because several different parallel operations

--- a/enrich/crunchbase/script.js
+++ b/enrich/crunchbase/script.js
@@ -6,7 +6,7 @@ dot.config({ path: `../../.env.development` })
 const { crunchbaseEnrich, mapCrunchbase } = require("./crunchbase")
 const { camelizeKeys } = require("../../backend/src/utils")
 
-const BASE = "appNYMWxGF1jMaf5V"
+const BASE = process.env.AIRTABLE_BASE_ID
 const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY }).base(BASE)
 
 async function asyncForEach(array, callback) {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,6 +4,16 @@ require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })
 
+// since AIRTABLE_BASE_ID was recently introduced, we add an error message to ask to update the
+// project configuration.
+if (!process.env.AIRTABLE_BASE_ID) {
+  console.log(
+    `AIRTABLE_BASE_ID property is missing from your env (.env.development file). 
+    See .env.sample as example.`
+  )
+  return
+}
+
 const config = {
   siteMetadata: {
     title: `Climatescape`,
@@ -30,7 +40,7 @@ const config = {
         apiKey: process.env.AIRTABLE_API_KEY,
         tables: [
           {
-            baseId: `appNYMWxGF1jMaf5V`,
+            baseId: process.env.AIRTABLE_BASE_ID,
             tableName: `Organizations`,
             tableView: `Published`,
             mapping: {
@@ -47,42 +57,42 @@ const config = {
             ],
           },
           {
-            baseId: `appNYMWxGF1jMaf5V`,
+            baseId: process.env.AIRTABLE_BASE_ID,
             tableName: "Contributors",
             tableView: "Published",
             mapping: { Avatar: `fileNode` },
           },
           {
-            baseId: `appNYMWxGF1jMaf5V`,
+            baseId: process.env.AIRTABLE_BASE_ID,
             tableName: "LinkedIn Profiles",
             tableView: "Grid view",
             mapping: { Logo: `fileNode` },
           },
           {
-            baseId: `appNYMWxGF1jMaf5V`,
+            baseId: process.env.AIRTABLE_BASE_ID,
             tableName: "Categories",
             mapping: { Cover: `fileNode` },
             tableView: "All Categories",
             tableLinks: [`Parent`, `Organizations`],
           },
           {
-            baseId: `appNYMWxGF1jMaf5V`,
+            baseId: process.env.AIRTABLE_BASE_ID,
             tableName: "Capital Profiles",
             tableLinks: [`Organization`, `Capital_Type`],
           },
           {
-            baseId: `appNYMWxGF1jMaf5V`,
+            baseId: process.env.AIRTABLE_BASE_ID,
             tableName: "Crunchbase ODM",
             tableLinks: [`Organization`],
             mapping: { Logo: `fileNode` },
           },
           {
-            baseId: `appNYMWxGF1jMaf5V`,
+            baseId: process.env.AIRTABLE_BASE_ID,
             tableName: "Sources",
             tableLinks: [`Organizations`],
           },
           {
-            baseId: `appNYMWxGF1jMaf5V`,
+            baseId: process.env.AIRTABLE_BASE_ID,
             tableName: "Capital Types",
             tableLinks: [`Capital_Profiles`],
             mapping: { Cover: `fileNode` },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,11 +7,10 @@ require("dotenv").config({
 // since AIRTABLE_BASE_ID was recently introduced, we add an error message to ask to update the
 // project configuration.
 if (!process.env.AIRTABLE_BASE_ID) {
-  console.log(
+  throw new Error(
     `AIRTABLE_BASE_ID property is missing from your env (.env.development file).
     See .env.sample as example.`
   )
-  process.exit(1)
 }
 
 const config = {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,10 +8,10 @@ require("dotenv").config({
 // project configuration.
 if (!process.env.AIRTABLE_BASE_ID) {
   console.log(
-    `AIRTABLE_BASE_ID property is missing from your env (.env.development file). 
+    `AIRTABLE_BASE_ID property is missing from your env (.env.development file).
     See .env.sample as example.`
   )
-  return
+  process.exit(1)
 }
 
 const config = {


### PR DESCRIPTION
since we introduced the AIRTABLE_BASE_ID property on our .env files, this commit refactor our code to use it everywhere instead of having it hard-coded.