### PR TITLE
Sort organizations by favorites count

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,11 +1,18 @@
-AIRTABLE_API_KEY=YOUR_KEY_HERE
+#
+# Copy this file to .env.development to run this site locally
+#
+
+# The following variables are required to run the Gatsby site.
+# Only missing values need to be provided in most cases.
+AIRTABLE_API_KEY=
 AIRTABLE_BASE_ID=appNYMWxGF1jMaf5V
+GRAPHQL_URI=https://climatescape-hasura.herokuapp.com/v1/graphql
 AUTH0_DOMAIN=dev-cfkkvy6u.auth0.com
 AUTH0_CLIENT_ID=RkMEWIOef1ZTy5jE0BV5JPANOHDO39up
 GATSBY_ALGOLIA_APP_ID=SKYZAC71CL
 GATSBY_ALGOLIA_SEARCH_KEY=5d4b018d3b45f2db1398c038c46cfa8a
 
-# The following fields are only necessary to work on enrichment
+# The following variables are only necessary to work on enrichment
 TWITTER_API_KEY=
 TWITTER_API_SECRET=
 CRUNCHBASE_API_KEY=

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -4,13 +4,20 @@ require("dotenv").config({
   path: `../.env.${process.env.NODE_ENV}`,
 })
 
-// since AIRTABLE_BASE_ID was recently introduced, we add an error message to ask to update the
-// project configuration.
-if (!process.env.AIRTABLE_BASE_ID) {
-  throw new Error(
-    `AIRTABLE_BASE_ID property is missing from .env.${process.env.NODE_ENV}
-    See .env.sample as example.`
-  )
+const RequiredEnv = [
+  `GRAPHQL_URI`, `AIRTABLE_BASE_ID`, `AIRTABLE_API_KEY`, `AUTH0_DOMAIN`,
+  `AUTH0_CLIENT_ID`, `GATSBY_ALGOLIA_APP_ID`, `GATSBY_ALGOLIA_SEARCH_KEY`,
+]
+
+const missingEnv = RequiredEnv.filter(key => !process.env[key])
+
+// Fail fast if any of the required ENV variables are missing
+if (missingEnv.length) {
+  throw new Error(`
+    The following variable(s) are missing from .env.${process.env.NODE_ENV}:
+    ${missingEnv.join(`, `)}
+    Open .env.sample to learn how to fix this.
+  `)
 }
 
 const config = {
@@ -28,6 +35,7 @@ const config = {
       domain: process.env.AUTH0_DOMAIN,
       clientId: process.env.AUTH0_CLIENT_ID,
     },
+    graphqlUri: process.env.GRAPHQL_URI,
   },
   plugins: [
     {
@@ -35,6 +43,14 @@ const config = {
       options: {
         name: `images`,
         path: `${__dirname}/src/images`,
+      },
+    },
+    {
+      resolve: `gatsby-source-graphql`,
+      options: {
+        typeName: `Climatescape`,
+        fieldName: `climatescape`,
+        url: process.env.GRAPHQL_URI,
       },
     },
     {

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4448,6 +4448,32 @@
         "tslib": "^1.9.3"
       }
     },
+    "apollo-upload-client": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz",
+      "integrity": "sha512-lJ9/bk1BH1lD15WhWRha2J3+LrXrPIX5LP5EwiOUHv8PCORp4EUrcujrA3rI5hZeZygrTX8bshcuMdpqpSrvtA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "extract-files": "^8.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
+      }
+    },
     "apollo-utilities": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.3.tgz",
@@ -7291,6 +7317,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+    },
     "date-fns": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.11.1.tgz",
@@ -7719,6 +7750,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
     "des.js": {
       "version": "1.0.1",
@@ -9350,6 +9386,11 @@
           }
         }
       }
+    },
+    "extract-files": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-8.1.0.tgz",
+      "integrity": "sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -12480,6 +12521,51 @@
         }
       }
     },
+    "gatsby-source-graphql": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/gatsby-source-graphql/-/gatsby-source-graphql-2.5.1.tgz",
+      "integrity": "sha512-RfayUkWLDJnmckPjnXowiF1KIlaCTOxOrPjQ56yNqbUW0PsUanvLpZ2E7Vbw5qW/VZbP1aUp0yH/qKKQrhLbrw==",
+      "requires": {
+        "@babel/runtime": "^7.9.6",
+        "apollo-link": "1.2.14",
+        "apollo-link-http": "^1.5.17",
+        "dataloader": "^2.0.0",
+        "graphql": "^14.6.0",
+        "graphql-tools": "^5.0.0",
+        "invariant": "^2.2.4",
+        "node-fetch": "^1.7.3",
+        "uuid": "^3.4.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
     "gatsby-telemetry": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.2.3.tgz",
@@ -13045,6 +13131,48 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",
       "integrity": "sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA=="
+    },
+    "graphql-tools": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-5.0.0.tgz",
+      "integrity": "sha512-5zn3vtn//382b7G3Wzz3d5q/sh+f7tVrnxeuhTMTJ7pWJijNqLxH7VEzv8VwXCq19zAzHYEosFHfXiK7qzvk7w==",
+      "requires": {
+        "apollo-link": "^1.2.14",
+        "apollo-upload-client": "^13.0.0",
+        "deprecated-decorator": "^0.1.6",
+        "form-data": "^3.0.0",
+        "iterall": "^1.3.0",
+        "node-fetch": "^2.6.0",
+        "tslib": "^1.11.1",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "tslib": {
+          "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
+          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
+      }
     },
     "graphql-type-json": {
       "version": "0.2.4",

--- a/site/package.json
+++ b/site/package.json
@@ -37,6 +37,7 @@
     "gatsby-plugin-sharp": "^2.5.3",
     "gatsby-source-airtable": "^2.1.0",
     "gatsby-source-filesystem": "^2.2.2",
+    "gatsby-source-graphql": "^2.5.1",
     "gatsby-transformer-sharp": "^2.4.3",
     "graphql-tag": "^2.10.3",
     "isomorphic-fetch": "^2.2.1",

--- a/site/src/components/ApolloProvider.js
+++ b/site/src/components/ApolloProvider.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
 import { ApolloClient, ApolloLink, InMemoryCache, HttpLink } from "apollo-boost"
 import { ApolloProvider as VanillaApolloProvider } from "react-apollo"
 import { setContext } from "apollo-link-context"
@@ -8,6 +9,15 @@ import { useAuth0 } from "./Auth0Provider"
 
 export const ApolloProvider = ({ children }) => {
   const { getTokenSilently, isAuthenticated } = useAuth0()
+  const { site: { siteMetadata }} = useStaticQuery(graphql`
+    query ApolloProviderQuery {
+      site {
+        siteMetadata {
+          graphqlUri
+        }
+      }
+    }
+  `)
 
   const tokenLink = setContext(async () => {
     if (!isAuthenticated) return {}
@@ -26,7 +36,7 @@ export const ApolloProvider = ({ children }) => {
   })
 
   const httpLink = new HttpLink({
-    uri: "https://climatescape-hasura.herokuapp.com/v1/graphql",
+    uri: siteMetadata.graphqlUri,
     fetch,
   })
 

--- a/site/src/components/ApolloProvider.js
+++ b/site/src/components/ApolloProvider.js
@@ -9,7 +9,9 @@ import { useAuth0 } from "./Auth0Provider"
 
 export const ApolloProvider = ({ children }) => {
   const { getTokenSilently, isAuthenticated } = useAuth0()
-  const { site: { siteMetadata }} = useStaticQuery(graphql`
+  const {
+    site: { siteMetadata },
+  } = useStaticQuery(graphql`
     query ApolloProviderQuery {
       site {
         siteMetadata {

--- a/site/src/components/FavoriteButton.js
+++ b/site/src/components/FavoriteButton.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useMemo } from "react"
 import noop from "lodash/noop"
 import classnames from "classnames"
 import { useMutation } from "@apollo/react-hooks"
@@ -38,7 +38,7 @@ export default function FavoriteButton({
   const [count, setCount] = useState()
   const favorited = !!favoriteId
 
-  useEffect(() => {
+  useMemo(() => {
     setFavoriteId(propFavoriteId)
     setCount(propCount || 0)
   }, [propFavoriteId, propCount])

--- a/site/src/pages/capital.js
+++ b/site/src/pages/capital.js
@@ -2,11 +2,10 @@ import React, { useMemo } from "react"
 import { graphql } from "gatsby"
 import flatMap from "lodash/flatMap"
 import { useFavorites, mergeFavorites } from "../utils/favorites"
-
+import { sortOrganizations } from "../utils/organizations"
 import {
   transformOrganizations,
   transformCapitalTypes,
-  sortOrganizations,
 } from "../utils/airtable"
 
 import Layout from "../components/layout"

--- a/site/src/pages/capital.js
+++ b/site/src/pages/capital.js
@@ -21,11 +21,12 @@ const CapitalTemplate = ({
     allOrganizations: allOrganizationData,
     activeType: activeTypeData,
     site,
+    climatescape,
   },
   pageContext: { activeTypeId },
 }) => {
   const [filter, setFilter, applyFilter] = useOrganizationFilterState()
-  const favorites = useFavorites()
+  const favorites = useFavorites(climatescape)
 
   const capitalTypes = transformCapitalTypes(capitalTypeNodes)
   const activeType = capitalTypes.find(({ id }) => id === activeTypeId)
@@ -145,6 +146,8 @@ export const query = graphql`
         }
       }
     }
+
+    ...StaticFavorites
 
     site {
       siteMetadata {

--- a/site/src/templates/organization.js
+++ b/site/src/templates/organization.js
@@ -182,7 +182,7 @@ const CapitalSection = ({
 
 export default function OrganizationTemplate({ data }) {
   const siteTitle = data.site.siteMetadata.title
-  const favorites = useFavorites()
+  const favorites = useFavorites(data.climatescape)
 
   const org = transformOrganization(data.organization, (raw, out) => ({
     ...out,
@@ -274,7 +274,7 @@ export const query = graphql`
         title
       }
     }
-
+    ...StaticFavorites
     organization: airtable(table: { eq: "Organizations" }, id: { eq: $id }) {
       recordId
       data {

--- a/site/src/templates/organizations.js
+++ b/site/src/templates/organizations.js
@@ -1,11 +1,10 @@
 import React, { useMemo } from "react"
 import { graphql } from "gatsby"
 import uniqBy from "lodash/uniqBy"
-
+import { sortOrganizations } from "../utils/organizations"
 import {
   transformCategories,
   transformOrganizations,
-  sortOrganizations,
 } from "../utils/airtable"
 
 import Layout from "../components/layout"

--- a/site/src/templates/organizations.js
+++ b/site/src/templates/organizations.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
-import { uniqBy } from "lodash"
+import uniqBy from "lodash/uniqby"
+import sortBy from "lodash/sortby"
 
 import { transformCategories, transformOrganizations } from "../utils/airtable"
 
@@ -17,7 +18,7 @@ function OrganizationsTemplate({
   pageContext: { categoryId, categoryName, categoryCounts },
 }) {
   const [filter, setFilter, applyFilter] = useOrganizationFilterState()
-  const favorites = useFavorites()
+  const favorites = useFavorites(data.climatescape)
 
   // We need to combine organizations from the query for sub-categories
   // and top-categories which might include duplicate orgs.
@@ -138,6 +139,7 @@ export const query = graphql`
         ...OrganizationCard
       }
     }
+    ...StaticFavorites
   }
 `
 

--- a/site/src/templates/organizations.js
+++ b/site/src/templates/organizations.js
@@ -2,10 +2,7 @@ import React, { useMemo } from "react"
 import { graphql } from "gatsby"
 import uniqBy from "lodash/uniqBy"
 import { sortOrganizations } from "../utils/organizations"
-import {
-  transformCategories,
-  transformOrganizations,
-} from "../utils/airtable"
+import { transformCategories, transformOrganizations } from "../utils/airtable"
 
 import Layout from "../components/layout"
 import OrganizationCard from "../components/OrganizationCard"

--- a/site/src/templates/organizations.js
+++ b/site/src/templates/organizations.js
@@ -2,7 +2,11 @@ import React, { useMemo } from "react"
 import { graphql } from "gatsby"
 import uniqBy from "lodash/uniqBy"
 
-import { transformCategories, transformOrganizations, sortOrganizations } from "../utils/airtable"
+import {
+  transformCategories,
+  transformOrganizations,
+  sortOrganizations,
+} from "../utils/airtable"
 
 import Layout from "../components/layout"
 import OrganizationCard from "../components/OrganizationCard"

--- a/site/src/templates/organizations.js
+++ b/site/src/templates/organizations.js
@@ -1,8 +1,8 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { graphql } from "gatsby"
 import uniqBy from "lodash/uniqBy"
 
-import { transformCategories, transformOrganizations } from "../utils/airtable"
+import { transformCategories, transformOrganizations, sortOrganizations } from "../utils/airtable"
 
 import Layout from "../components/layout"
 import OrganizationCard from "../components/OrganizationCard"
@@ -10,7 +10,7 @@ import IndexHeader from "../components/IndexHeader"
 import { useOrganizationFilterState } from "../components/OrganizationFilter"
 import SEO from "../components/seo"
 import CategoryList from "../components/CategoryList"
-import { useFavorites } from "../utils/favorites"
+import { useFavorites, mergeFavorites } from "../utils/favorites"
 
 function OrganizationsTemplate({
   data,
@@ -18,22 +18,29 @@ function OrganizationsTemplate({
 }) {
   const [filter, setFilter, applyFilter] = useOrganizationFilterState()
   const favorites = useFavorites(data.climatescape)
-
-  // We need to combine organizations from the query for sub-categories
-  // and top-categories which might include duplicate orgs.
-  const orgs = uniqBy(
-    [...data.subOrganizations?.nodes, ...data.topOrganizations?.nodes],
-    org => org.recordId
-  )
-
-  const allOrganizations = transformOrganizations(orgs, (raw, org) => ({
-    ...org,
-    favorite: favorites[org.recordId],
-  }))
-  const organizations = applyFilter(allOrganizations)
+  const { organizationAddFormUrl } = data.site.siteMetadata
   const categories = transformCategories(data.categories.nodes)
 
-  const { organizationAddFormUrl } = data.site.siteMetadata
+  // On first render, perform some data transformations on the raw Gatsby query
+  const allOrgs = useMemo(() => {
+    // Merge results from the primary/seconary queries into one array
+    const rawOrgs = uniqBy(
+      [...data.subOrganizations?.nodes, ...data.topOrganizations?.nodes],
+      org => org.recordId
+    )
+
+    // Turn raw Airtable data into something we can work with
+    const transformedOrgs = transformOrganizations(rawOrgs)
+
+    // Add initial favorite counts from Hasura via Gatsby
+    const favoritedOrgs = mergeFavorites(transformedOrgs, favorites)
+
+    // Sort once using this data
+    return sortOrganizations(favoritedOrgs)
+  }, [data])
+
+  const favoritedOrgs = mergeFavorites(allOrgs, favorites)
+  const filteredOrgs = applyFilter(favoritedOrgs)
 
   return (
     <Layout contentClassName="bg-gray-100 px-3 sm:px-6">
@@ -53,13 +60,13 @@ function OrganizationsTemplate({
             filter={filter}
             onClearFilter={() => setFilter.none()}
             onApplyFilter={setFilter}
-            organizations={organizations}
-            allOrganizations={allOrganizations}
+            organizations={filteredOrgs}
+            allOrganizations={allOrgs}
             showFilters={["location", "role", "headcount", "orgType"]}
           />
 
           <div>
-            {organizations.map(org => (
+            {filteredOrgs.map(org => (
               <OrganizationCard
                 organization={org}
                 categoryId={categoryId}

--- a/site/src/templates/organizations.js
+++ b/site/src/templates/organizations.js
@@ -1,7 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
-import uniqBy from "lodash/uniqby"
-import sortBy from "lodash/sortby"
+import uniqBy from "lodash/uniqBy"
 
 import { transformCategories, transformOrganizations } from "../utils/airtable"
 

--- a/site/src/utils/airtable.js
+++ b/site/src/utils/airtable.js
@@ -34,7 +34,6 @@ function transformCategory(category) {
 }
 
 export function transformCategories(rawCategories) {
-  console.log("EXPENSIVE - transform categories")
   const categories = rawCategories
     .map(transformCategory)
     .sort((a, b) => stringCompare(a.name, b.name))
@@ -152,17 +151,17 @@ export function transformOrganization(raw, userTransform = (_, out) => out) {
   })
 }
 
-export const sortOrganizations = organizations => sortBy(
-  organizations,
-  [
+export const sortOrganizations = organizations =>
+  sortBy(organizations, [
     org => -(org.favorite?.count || 0), // First by number of favs (DESC)
     org => !trim(org.description).length, // Then by presence of description
     "title", // Finally by title
-  ]
-)
+  ])
 
 export function transformOrganizations(orgs, userTransform) {
-  const organizations = orgs.map(org => transformOrganization(org, userTransform))
+  const organizations = orgs.map(org =>
+    transformOrganization(org, userTransform)
+  )
 
   if (typeof window === "object") {
     // eslint-disable-next-line no-restricted-globals

--- a/site/src/utils/airtable.js
+++ b/site/src/utils/airtable.js
@@ -1,5 +1,6 @@
 import compact from "lodash/compact"
 import sortBy from "lodash/sortBy"
+import trim from "lodash/trim"
 
 import { stringCompare } from "./string"
 import { makeSlug } from "./slug"
@@ -153,7 +154,11 @@ export function transformOrganization(raw, userTransform = (_, out) => out) {
 export function transformOrganizations(orgs, userTransform) {
   const organizations = sortBy(
     orgs.map(org => transformOrganization(org, userTransform)),
-    [org => -(org.favorite?.count || 0), "title"]
+    [
+      org => -(org.favorite?.count || 0), // Number of favs DESC
+      org => !trim(org.description).length, // Missing description LAST
+      "title", // By title ASC
+    ]
   )
 
   if (typeof window === "object") {

--- a/site/src/utils/airtable.js
+++ b/site/src/utils/airtable.js
@@ -1,6 +1,4 @@
 import compact from "lodash/compact"
-import sortBy from "lodash/sortBy"
-import trim from "lodash/trim"
 
 import { stringCompare } from "./string"
 import { makeSlug } from "./slug"
@@ -150,13 +148,6 @@ export function transformOrganization(raw, userTransform = (_, out) => out) {
     thumbnails: transformThumbnails(Photos),
   })
 }
-
-export const sortOrganizations = organizations =>
-  sortBy(organizations, [
-    org => -(org.favorite?.count || 0), // First by number of favs (DESC)
-    org => !trim(org.description).length, // Then by presence of description
-    "title", // Finally by title
-  ])
 
 export function transformOrganizations(orgs, userTransform) {
   const organizations = orgs.map(org =>

--- a/site/src/utils/airtable.js
+++ b/site/src/utils/airtable.js
@@ -34,6 +34,7 @@ function transformCategory(category) {
 }
 
 export function transformCategories(rawCategories) {
+  console.log("EXPENSIVE - transform categories")
   const categories = rawCategories
     .map(transformCategory)
     .sort((a, b) => stringCompare(a.name, b.name))
@@ -151,15 +152,17 @@ export function transformOrganization(raw, userTransform = (_, out) => out) {
   })
 }
 
+export const sortOrganizations = organizations => sortBy(
+  organizations,
+  [
+    org => -(org.favorite?.count || 0), // First by number of favs (DESC)
+    org => !trim(org.description).length, // Then by presence of description
+    "title", // Finally by title
+  ]
+)
+
 export function transformOrganizations(orgs, userTransform) {
-  const organizations = sortBy(
-    orgs.map(org => transformOrganization(org, userTransform)),
-    [
-      org => -(org.favorite?.count || 0), // Number of favs DESC
-      org => !trim(org.description).length, // Missing description LAST
-      "title", // By title ASC
-    ]
-  )
+  const organizations = orgs.map(org => transformOrganization(org, userTransform))
 
   if (typeof window === "object") {
     // eslint-disable-next-line no-restricted-globals

--- a/site/src/utils/airtable.js
+++ b/site/src/utils/airtable.js
@@ -1,5 +1,5 @@
 import compact from "lodash/compact"
-import sortBy from "lodash/sortby"
+import sortBy from "lodash/sortBy"
 
 import { stringCompare } from "./string"
 import { makeSlug } from "./slug"
@@ -153,10 +153,7 @@ export function transformOrganization(raw, userTransform = (_, out) => out) {
 export function transformOrganizations(orgs, userTransform) {
   const organizations = sortBy(
     orgs.map(org => transformOrganization(org, userTransform)),
-    [
-      org => -(org.favorite?.count || 0),
-      "title"
-    ]
+    [org => -(org.favorite?.count || 0), "title"]
   )
 
   if (typeof window === "object") {

--- a/site/src/utils/airtable.js
+++ b/site/src/utils/airtable.js
@@ -1,4 +1,5 @@
 import compact from "lodash/compact"
+import sortBy from "lodash/sortby"
 
 import { stringCompare } from "./string"
 import { makeSlug } from "./slug"
@@ -150,9 +151,13 @@ export function transformOrganization(raw, userTransform = (_, out) => out) {
 }
 
 export function transformOrganizations(orgs, userTransform) {
-  const organizations = orgs
-    .map(org => transformOrganization(org, userTransform))
-    .sort((a, b) => stringCompare(a.title, b.title))
+  const organizations = sortBy(
+    orgs.map(org => transformOrganization(org, userTransform)),
+    [
+      org => -(org.favorite?.count || 0),
+      "title"
+    ]
+  )
 
   if (typeof window === "object") {
     // eslint-disable-next-line no-restricted-globals

--- a/site/src/utils/favorites.js
+++ b/site/src/utils/favorites.js
@@ -2,8 +2,8 @@ import { keyBy, mapValues } from "lodash"
 import { useState, useEffect } from "react"
 import { useLazyQuery } from "@apollo/react-hooks"
 import gql from "graphql-tag"
-import { useAuth0 } from "../components/Auth0Provider"
 import { graphql } from "gatsby"
+import { useAuth0 } from "../components/Auth0Provider"
 
 export const GetFavorites = gql`
   query GetFavorites($loggedIn: Boolean!, $userId: uuid) {

--- a/site/src/utils/favorites.js
+++ b/site/src/utils/favorites.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react"
 import { useLazyQuery } from "@apollo/react-hooks"
 import gql from "graphql-tag"
 import { useAuth0 } from "../components/Auth0Provider"
+import { graphql } from "gatsby"
 
 export const GetFavorites = gql`
   query GetFavorites($loggedIn: Boolean!, $userId: uuid) {
@@ -14,6 +15,18 @@ export const GetFavorites = gql`
     favoritesCount {
       recordId
       count
+    }
+  }
+`
+
+// For Gatsby to pull favorites when building the site
+export const query = graphql`
+  fragment StaticFavorites on Query {
+    climatescape {
+      favoritesCount {
+        recordId
+        count
+      }
     }
   }
 `
@@ -40,7 +53,7 @@ const APP_CLAIM = "https://climatescape.org/app"
 //   "rec1": { count: 14, id: "uuid-of-users-favorite" },
 //   "rec2": { count: 2, id: null },
 // }
-export function useFavorites() {
+export function useFavorites(defaultData) {
   const { loading: authLoading, user } = useAuth0()
   const [favorites, setFavorites] = useState({})
   const uuid = user?.[APP_CLAIM]?.uuid
@@ -57,8 +70,10 @@ export function useFavorites() {
   }, [authLoading])
 
   useEffect(() => {
-    if (data) setFavorites(indexFavoritesData(data))
-  }, [data])
+    const favData = data || defaultData
+
+    if (favData) setFavorites(indexFavoritesData(favData))
+  }, [data, defaultData])
 
   return favorites
 }

--- a/site/src/utils/favorites.js
+++ b/site/src/utils/favorites.js
@@ -55,8 +55,8 @@ const APP_CLAIM = "https://climatescape.org/app"
 // }
 export function useFavorites(defaultData) {
   const { loading: authLoading, user } = useAuth0()
-  const [favorites, setFavorites] = useState(
-    () => indexFavoritesData(defaultData)
+  const [favorites, setFavorites] = useState(() =>
+    indexFavoritesData(defaultData)
   )
   const uuid = user?.[APP_CLAIM]?.uuid
 
@@ -78,7 +78,8 @@ export function useFavorites(defaultData) {
   return favorites
 }
 
-export const mergeFavorites = (orgs, favs) => orgs.map(org => ({
-  ...org,
-  favorite: favs[org.recordId]
-}))
+export const mergeFavorites = (orgs, favs) =>
+  orgs.map(org => ({
+    ...org,
+    favorite: favs[org.recordId],
+  }))

--- a/site/src/utils/favorites.js
+++ b/site/src/utils/favorites.js
@@ -1,11 +1,11 @@
 import { keyBy, mapValues } from "lodash"
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { useLazyQuery } from "@apollo/react-hooks"
 import gql from "graphql-tag"
 import { graphql } from "gatsby"
 import { useAuth0 } from "../components/Auth0Provider"
 
-export const GetFavorites = gql`
+const GetFavorites = gql`
   query GetFavorites($loggedIn: Boolean!, $userId: uuid) {
     favorites(where: { userId: { _eq: $userId } }) @include(if: $loggedIn) {
       id
@@ -55,7 +55,9 @@ const APP_CLAIM = "https://climatescape.org/app"
 // }
 export function useFavorites(defaultData) {
   const { loading: authLoading, user } = useAuth0()
-  const [favorites, setFavorites] = useState({})
+  const [favorites, setFavorites] = useState(
+    () => indexFavoritesData(defaultData)
+  )
   const uuid = user?.[APP_CLAIM]?.uuid
 
   const [getFavorites, { data }] = useLazyQuery(GetFavorites, {
@@ -65,15 +67,18 @@ export function useFavorites(defaultData) {
     },
   })
 
+  // Only fetch favorites from the server once we know if a user is logged in
   useEffect(() => {
     if (!authLoading) getFavorites()
   }, [authLoading])
 
-  useEffect(() => {
-    const favData = data || defaultData
-
-    if (favData) setFavorites(indexFavoritesData(favData))
-  }, [data, defaultData])
+  // Index and set favorites any time data changes
+  useMemo(() => data && setFavorites(indexFavoritesData(data)), [data])
 
   return favorites
 }
+
+export const mergeFavorites = (orgs, favs) => orgs.map(org => ({
+  ...org,
+  favorite: favs[org.recordId]
+}))

--- a/site/src/utils/organizations.js
+++ b/site/src/utils/organizations.js
@@ -1,0 +1,12 @@
+import sortBy from "lodash/sortBy"
+import trim from "lodash/trim"
+
+export const sortOrganizations = organizations =>
+  sortBy(organizations, [
+    // First by number of favs (DESC)
+    ({ favorite }) => -(favorite?.count || 0),
+    // Then by presence of description
+    ({ description }) => !trim(description).length,
+    // Finally by title, case-insensitive (ASC)
+    ({ title }) => title.toUpperCase(),
+  ])


### PR DESCRIPTION
The goal of this PR is to sort organizations by their favorites count. To make this work better, I introduced our GraphQL API to Gatsby during the build process. This lets us do the sorting once when building the static site, then update it when we fetch on the client. I'm hoping this keeps things mostly in the same order to avoid a confusing UX when the client-side favorites come in. One side effect with the current implementation is that orgs move up/down the list as a user favorites them.

If this behavior feels weird in testing we can pretty easily move to build-only sorting. It was just extra work so I avoided it for now.