### PR TITLE
Always build site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,5 @@
   base    = "site"
   publish = "public"
   command = "npm run build"
+  # Always build the site, regardless of code updates: https://bit.ly/3fxbQO6
+  ignore = "sh this-always-fails"


### PR DESCRIPTION
Netlify has a default optimization that will short-circuit builds
when the code hasn't changed. We don't want this behavior since our
data often changes without any code changes.