### PR TITLE
query and display category definitions on organizations page

### DIFF
--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -115,6 +115,7 @@ exports.createPages = async ({ graphql, actions }) => {
           id
           data {
             Name
+            Definition
             Organizations {
               id
               data {
@@ -155,6 +156,7 @@ exports.createPages = async ({ graphql, actions }) => {
       component: path.resolve(`./src/templates/organizations.js`),
       context: {
         categoryName: category.data.Name,
+        categoryDefinition: category.data.Definition,
         categoryId: category.id,
         categoryCounts,
       },

--- a/site/src/components/IndexHeader.js
+++ b/site/src/components/IndexHeader.js
@@ -6,6 +6,7 @@ import OrganizationFilter from "./OrganizationFilter"
 
 const IndexHeader = ({
   title,
+  definition,
   buttonText,
   buttonUrl,
   filter,
@@ -35,6 +36,7 @@ const IndexHeader = ({
         </a>
       )}
     </div>
+    {definition && <p className="mt-3 mb-4 text-sm">{definition}</p>}
 
     <OrganizationFilter
       currentFilter={filter}

--- a/site/src/templates/organizations.js
+++ b/site/src/templates/organizations.js
@@ -14,7 +14,7 @@ import { useFavorites, mergeFavorites } from "../utils/favorites"
 
 function OrganizationsTemplate({
   data,
-  pageContext: { categoryId, categoryName, categoryCounts },
+  pageContext: { categoryId, categoryName, categoryDefinition, categoryCounts },
 }) {
   const [filter, setFilter, applyFilter] = useOrganizationFilterState()
   const favorites = useFavorites(data.climatescape)
@@ -55,6 +55,7 @@ function OrganizationsTemplate({
         <div className="lg:w-3/5">
           <IndexHeader
             title={categoryName || "All Organizations"}
+            definition={categoryDefinition}
             buttonText="Add"
             buttonUrl={organizationAddFormUrl}
             filter={filter}
@@ -92,6 +93,7 @@ export const query = graphql`
         id
         data {
           Name
+          Definition
           Parent {
             id
             data {

--- a/site/src/utils/airtable.js
+++ b/site/src/utils/airtable.js
@@ -10,7 +10,7 @@ function transformCategory(category) {
 
   const {
     id,
-    data: { Name, Count, Cover, Parent },
+    data: { Name, Definition, Count, Cover, Parent },
   } = category
   const parent = transformCategory(Parent?.[0])
   const cover = Cover?.localFiles?.[0]?.childImageSharp
@@ -19,6 +19,7 @@ function transformCategory(category) {
     id,
     name: Name,
     fullName: compact([parent?.name, Name]).join(" > "),
+    definition: Definition,
     count: Count,
     cover: cover?.fluid || cover?.resize,
     slug: `/categories/${makeSlug(Name)}`,


### PR DESCRIPTION
closes #308 

- category definition is now available on /organizations page context.
- if definition exists, it's being displayed on category page.